### PR TITLE
Add round summary text

### DIFF
--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -10,6 +10,7 @@ contract ImpactEvaluator is AccessControl {
         address[] participantAddresses;
         uint[] participantScores;
         bool scoresSubmitted;
+        string summaryText;
     }
 
     Round[] public rounds;
@@ -55,7 +56,8 @@ contract ImpactEvaluator is AccessControl {
     function setScores(
         uint roundIndex,
         address[] memory addresses,
-        uint[] memory scores
+        uint[] memory scores,
+        string memory summaryText
     ) public {
         require(hasRole(EVALUATE_ROLE, msg.sender), "Not an evaluator");
         require(roundIndex == rounds.length - 2, "Wrong round");
@@ -67,6 +69,7 @@ contract ImpactEvaluator is AccessControl {
         require(!round.scoresSubmitted, "Scores already submitted");
         round.participantAddresses = addresses;
         round.participantScores = scores;
+        round.summaryText = summaryText;
         round.scoresSubmitted = true;
         rounds[roundIndex] = round;
         reward(addresses, scores);

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -41,7 +41,12 @@ contract ImpactEvaluatorTest is Test {
             1000
         );
         vm.expectRevert("Not an evaluator");
-        impactEvaluator.setScores(0, new address[](0), new uint[](0));
+        impactEvaluator.setScores(
+            0,
+            new address[](0),
+            new uint[](0),
+            "no measurements"
+        );
     }
 
     function test_SetScores() public {
@@ -59,24 +64,45 @@ contract ImpactEvaluatorTest is Test {
             address(this)
         );
         vm.expectRevert("Wrong round");
-        impactEvaluator.setScores(1, new address[](0), new uint[](0));
+        impactEvaluator.setScores(
+            1,
+            new address[](0),
+            new uint[](0),
+            "no measurements"
+        );
         vm.expectRevert("Addresses and scores length mismatch");
-        impactEvaluator.setScores(0, new address[](1), new uint[](0));
+        impactEvaluator.setScores(
+            0,
+            new address[](1),
+            new uint[](0),
+            "one peer"
+        );
 
         address[] memory addresses = new address[](1);
         addresses[0] = address(0x1);
         uint[] memory scores = new uint[](1);
         scores[0] = 1;
-        impactEvaluator.setScores(0, addresses, scores);
+        impactEvaluator.setScores(
+            0,
+            addresses,
+            scores,
+            "1 task performed"
+        );
 
         ImpactEvaluator.Round memory round = impactEvaluator.getRound(0);
         assertEq(round.participantAddresses.length, 1);
         assertEq(round.participantScores.length, 1);
         assertEq(round.participantAddresses[0], address(0x1));
         assertEq(round.participantScores[0], 1);
+        assertEq(round.summaryText, "1 task performed");
         assertEq(round.scoresSubmitted, true);
 
         vm.expectRevert("Scores already submitted");
-        impactEvaluator.setScores(0, addresses, scores);
+        impactEvaluator.setScores(
+            0,
+            addresses,
+            scores,
+            "1 task performed"
+        );
     }
 }


### PR DESCRIPTION
This allows round summaries to be added, eg "10GB retrieved, 20 retrievals, 50 peers".

Eventually this should be structured data, I'm adding this as an iteration starting point.