### PR TITLE
feat: add gas estimator

### DIFF
--- a/contract-utils/Cargo.lock
+++ b/contract-utils/Cargo.lock
@@ -865,6 +865,8 @@ dependencies = [
  "contract-bindings",
  "ethers",
  "fevm-utils",
+ "num-bigint",
+ "num-traits",
  "once_cell",
  "tokio",
 ]

--- a/contract-utils/Cargo.toml
+++ b/contract-utils/Cargo.toml
@@ -12,3 +12,5 @@ contract-bindings = { path= "../contract-bindings" }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread", "rt"] }
 once_cell = "1.17.1"
 assert_fs = "1.0.10"
+num-bigint = "0.4"
+num-traits = "0.2"

--- a/contract-utils/src/gas_estimator.rs
+++ b/contract-utils/src/gas_estimator.rs
@@ -1,0 +1,89 @@
+extern crate num_bigint;
+extern crate num_traits;
+
+use num_bigint::BigInt;
+use num_traits::{ToPrimitive, Zero};
+
+#[derive(Clone, Debug)]
+pub struct GasOutputs {
+    base_fee_burn: BigInt,
+    over_estimation_burn: BigInt,
+    miner_penalty: BigInt,
+    miner_tip: BigInt,
+    refund: BigInt,
+    gas_refund: i64,
+    gas_burned: i64,
+}
+
+fn compute_gas_overestimation_burn(gas_used: i64, gas_limit: i64) -> (i64, i64) {
+    if gas_used == 0 {
+        return (0, gas_limit);
+    }
+    let over = gas_limit - (11 * gas_used) / 10;
+    if over < 0 {
+        return (gas_limit - gas_used, 0);
+    }
+    let over = std::cmp::min(over, gas_used);
+    let gas_to_burn =
+        (BigInt::from(gas_limit - gas_used) * BigInt::from(over)) / BigInt::from(gas_used);
+    (
+        gas_limit - gas_used - gas_to_burn.to_i64().unwrap(),
+        gas_to_burn.to_i64().unwrap(),
+    )
+}
+
+pub fn compute_gas_outputs(
+    gas_used: i64,
+    gas_limit: i64,
+    base_fee: &BigInt,
+    fee_cap: &BigInt,
+    gas_premium: &BigInt,
+    charge_network_fee: bool,
+) -> GasOutputs {
+    let gas_used_big = BigInt::from(gas_used);
+    let mut outputs = GasOutputs {
+        base_fee_burn: BigInt::zero(),
+        over_estimation_burn: BigInt::zero(),
+        miner_penalty: BigInt::zero(),
+        miner_tip: BigInt::zero(),
+        refund: BigInt::zero(),
+        gas_refund: 0,
+        gas_burned: 0,
+    };
+
+    let mut base_fee_to_pay = base_fee.clone();
+    if &base_fee_to_pay > fee_cap {
+        base_fee_to_pay = fee_cap.clone();
+        outputs.miner_penalty = (base_fee - fee_cap) * &gas_used_big;
+    }
+
+    if charge_network_fee {
+        outputs.base_fee_burn = &base_fee_to_pay * &gas_used_big;
+    }
+
+    let mut miner_tip = gas_premium.clone();
+    if &(&base_fee_to_pay + &miner_tip) > fee_cap {
+        miner_tip = fee_cap - &base_fee_to_pay;
+    }
+    outputs.miner_tip = &miner_tip * BigInt::from(gas_limit);
+
+    let (gas_refund, gas_burned) = compute_gas_overestimation_burn(gas_used, gas_limit);
+    outputs.gas_refund = gas_refund;
+    outputs.gas_burned = gas_burned;
+
+    if outputs.gas_burned != 0 {
+        let gas_burned_big = BigInt::from(outputs.gas_burned);
+        outputs.over_estimation_burn = &base_fee_to_pay * &gas_burned_big;
+        let miner_penalty = (base_fee - &base_fee_to_pay) * &gas_burned_big;
+        outputs.miner_penalty += miner_penalty;
+    }
+
+    let required_funds = BigInt::from(gas_limit) * fee_cap;
+    let refund = &required_funds
+        - &outputs.base_fee_burn
+        - &outputs.miner_tip
+        - &outputs.over_estimation_burn;
+    outputs.refund = refund;
+
+    outputs
+}

--- a/contract-utils/src/lib.rs
+++ b/contract-utils/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod gas_estimator;
 pub mod measure {
 
     use contract_bindings::measure::Measure;


### PR DESCRIPTION
## Changes:

Adds a gas estimator that takes gas related inputs and computes the total gas burned for a given transaction. In turn, this  can be turned into a dollar amount to how much a given transaction costs. 

Apart from creating price models for transactions, this will be useful when testing meridian on filecoin testnets. The gas prices on testnets are usually independent the mainnet. Using this estimator, we can run mainnet gas estimates for any testnet transactions and store those values to get a better idea of actual costs associated with changes. 


