### PR TITLE
refactor admin methods

### DIFF
--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -28,16 +28,12 @@ contract ImpactEvaluator is AccessControl {
         advanceRound();
     }
 
-    function advanceRound() private {
+    function advanceRound() public {
+        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not an admin");
         Round memory round;
         round.start = block.number;
         rounds.push(round);
         emit RoundStart(currentRoundIndex());
-    }
-
-    function adminAdvanceRound() public {
-        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not an admin");
-        advanceRound();
     }
 
     function maybeAdvanceRound() private {

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -18,7 +18,7 @@ contract ImpactEvaluatorTest is Test {
         assertEq(impactEvaluator.getRound(0).start, block.number);
         vm.expectEmit(false, false, false, true);
         emit RoundStart(1);
-        impactEvaluator.adminAdvanceRound();
+        impactEvaluator.advanceRound();
         assertEq(impactEvaluator.currentRoundIndex(), 1);
     }
 
@@ -54,7 +54,7 @@ contract ImpactEvaluatorTest is Test {
             address(this),
             1000
         );
-        impactEvaluator.adminAdvanceRound();
+        impactEvaluator.advanceRound();
         impactEvaluator.grantRole(
             impactEvaluator.EVALUATE_ROLE(),
             address(this)


### PR DESCRIPTION
@AmeanAsad I tried refactoring as you advised, but seems the contract doesn't automatically act as admin. I think that makes sense: When anyone calls `addMeasurement` and then that call internally calls `advanceRound`, the transaction is still executed by the original sender. Wdyt?

```
$ forge test
[⠢] Compiling...
[⠒] Compiling 2 files with 0.8.21
[⠢] Solc 0.8.21 finished in 871.67ms
Compiler run successful!

Running 4 tests for test/ImpactEvaluator.t.sol:ImpactEvaluatorTest
[FAIL. Reason: Not an admin] test_AddMeasurement() (gas: 107951)
[PASS] test_AdvanceRound() (gas: 1635023)
[PASS] test_SetScores() (gas: 1764257)
[FAIL. Reason: Not an admin] test_SetScoresNotEvaluator() (gas: 108017)
Test result: FAILED. 2 passed; 2 failed; 0 skipped; finished in 822.00µs
Ran 1 test suites: 2 tests passed, 2 failed, 0 skipped (4 total tests)

Failing tests:
Encountered 2 failing tests in test/ImpactEvaluator.t.sol:ImpactEvaluatorTest
[FAIL. Reason: Not an admin] test_AddMeasurement() (gas: 107951)
[FAIL. Reason: Not an admin] test_SetScoresNotEvaluator() (gas: 108017)

Encountered a total of 2 failing tests, 2 tests succeeded
```