### PR TITLE
Add automatic clean up after n rounds. Closes #10

### DIFF
--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -16,6 +16,7 @@ contract ImpactEvaluator is AccessControl {
     Round[] public rounds;
     uint public nextRoundLength = 10;
     uint public roundReward = 100;
+    uint public maxStoredRounds = 1000;
 
     event MeasurementsAdded(string cid, uint roundIndex);
     event RoundStart(uint roundIndex);
@@ -35,6 +36,9 @@ contract ImpactEvaluator is AccessControl {
         round.end = block.number + nextRoundLength;
         rounds.push(round);
         emit RoundStart(currentRoundIndex());
+        if (rounds.length > maxStoredRounds) {
+            
+        }
     }
 
     function adminAdvanceRound() public {
@@ -57,6 +61,11 @@ contract ImpactEvaluator is AccessControl {
     function setRoundReward(uint _roundReward) public {
         require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not an admin");
         roundReward = _roundReward;
+    }
+
+    function setMaxStoredRounds(uint _maxStoredRounds) public {
+        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not an admin");
+        maxStoredRounds = _maxStoredRounds;
     }
 
     function addMeasurements(string memory cid) public returns (uint) {

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -39,6 +39,7 @@ contract ImpactEvaluator is AccessControl {
         rounds.push(round);
         emit RoundStart(currentRoundIndex());
         if (rounds.length > maxStoredRounds) {
+            // TODO: protect against over/underflow
             delete rounds[rounds.length - maxStoredRounds - 1];
         }
     }

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -11,6 +11,7 @@ contract ImpactEvaluator is AccessControl {
         uint[] participantScores;
         bool scoresSubmitted;
         string summaryText;
+        bool exists;
     }
 
     Round[] public rounds;
@@ -34,10 +35,11 @@ contract ImpactEvaluator is AccessControl {
     function advanceRound() private {
         Round memory round;
         round.end = block.number + nextRoundLength;
+        round.exists = true;
         rounds.push(round);
         emit RoundStart(currentRoundIndex());
         if (rounds.length > maxStoredRounds) {
-            
+            delete rounds[rounds.length - maxStoredRounds - 1];
         }
     }
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -19,9 +19,8 @@ contract ImpactEvaluator is AccessControl {
     // public
     struct LinkedRound {
         Round round;
-        // Recursive structs aren't possible
-        // Use a single element mapping instead
-        mapping(uint => LinkedRound) previousLinkedRound;
+        // Recursive structs aren't possible, use a single element array instead
+        LinkedRound[] previousLinkedRound;
     }
 
     LinkedRound public currentLinkedRound;
@@ -44,7 +43,7 @@ contract ImpactEvaluator is AccessControl {
     receive() external payable {}
 
     function advanceRound() private {
-        LinkedRound storage linkedRound;
+        LinkedRound memory linkedRound;
         if (currentLinkedRound.round.exists) {
             linkedRound.round.index = currentLinkedRound.round.index + 1;
             linkedRound.previousLinkedRound[0] = currentLinkedRound;
@@ -60,7 +59,7 @@ contract ImpactEvaluator is AccessControl {
 
     function maybeRemoveOldestLinkedRound() private {
         if (currentLinkedRound.round.index >= maxStoredRounds) {
-            LinkedRound storage linkedRound = getLinkedRound(
+            LinkedRound memory linkedRound = getLinkedRound(
                 currentLinkedRound.round.index - maxStoredRounds
             );
             delete linkedRound.previousLinkedRound[0];
@@ -112,7 +111,7 @@ contract ImpactEvaluator is AccessControl {
             addresses.length == scores.length,
             "Addresses and scores length mismatch"
         );
-        LinkedRound storage linkedRound = getLinkedRound(roundIndex);
+        LinkedRound memory linkedRound = getLinkedRound(roundIndex);
         require(!linkedRound.round.scoresSubmitted, "Scores already submitted");
         linkedRound.round.participantAddresses = addresses;
         linkedRound.round.participantScores = scores;

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -67,8 +67,11 @@ contract ImpactEvaluator is AccessControl {
 
     function setMaxStoredRounds(uint _maxStoredRounds) public {
         require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not an admin");
-        // TODO: If the new maxStoredRounds is less than the current value,
-        // clean up
+        if (_maxStoredRounds < maxStoredRounds) {
+            for (uint i = 0; i < rounds.length - _maxStoredRounds; i++) {
+                delete rounds[i];
+            }
+        }
         maxStoredRounds = _maxStoredRounds;
     }
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -19,8 +19,9 @@ contract ImpactEvaluator is AccessControl {
     // public
     struct LinkedRound {
         Round round;
-        // Recursive structs aren't possible, use a single element array instead
-        LinkedRound[] previousLinkedRound;
+        // Recursive structs aren't possible
+        // Use a single element mapping instead
+        mapping(uint => LinkedRound) previousLinkedRound;
     }
 
     LinkedRound public currentLinkedRound;
@@ -43,7 +44,7 @@ contract ImpactEvaluator is AccessControl {
     receive() external payable {}
 
     function advanceRound() private {
-        LinkedRound memory linkedRound;
+        LinkedRound storage linkedRound;
         if (currentLinkedRound.round.exists) {
             linkedRound.round.index = currentLinkedRound.round.index + 1;
             linkedRound.previousLinkedRound[0] = currentLinkedRound;
@@ -59,7 +60,7 @@ contract ImpactEvaluator is AccessControl {
 
     function maybeRemoveOldestLinkedRound() private {
         if (currentLinkedRound.round.index >= maxStoredRounds) {
-            LinkedRound memory linkedRound = getLinkedRound(
+            LinkedRound storage linkedRound = getLinkedRound(
                 currentLinkedRound.round.index - maxStoredRounds
             );
             delete linkedRound.previousLinkedRound[0];
@@ -111,7 +112,7 @@ contract ImpactEvaluator is AccessControl {
             addresses.length == scores.length,
             "Addresses and scores length mismatch"
         );
-        LinkedRound memory linkedRound = getLinkedRound(roundIndex);
+        LinkedRound storage linkedRound = getLinkedRound(roundIndex);
         require(!linkedRound.round.scoresSubmitted, "Scores already submitted");
         linkedRound.round.participantAddresses = addresses;
         linkedRound.round.participantScores = scores;

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -67,6 +67,8 @@ contract ImpactEvaluator is AccessControl {
 
     function setMaxStoredRounds(uint _maxStoredRounds) public {
         require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not an admin");
+        // TODO: If the new maxStoredRounds is less than the current value,
+        // clean up
         maxStoredRounds = _maxStoredRounds;
     }
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -39,7 +39,6 @@ contract ImpactEvaluator is AccessControl {
         rounds.push(round);
         emit RoundStart(currentRoundIndex());
         if (rounds.length > maxStoredRounds) {
-            // TODO: protect against over/underflow
             delete rounds[rounds.length - maxStoredRounds - 1];
         }
     }

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -96,6 +96,7 @@ contract ImpactEvaluator is AccessControl {
             "Addresses and scores length mismatch"
         );
         Round storage round = rounds[roundIndex];
+        require(round.exists, "Round does not exist");
         require(!round.scoresSubmitted, "Scores already submitted");
         for (uint i = 0; i < addresses.length; i++) {
             round.scores[addresses[i]] = scores[i];

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -25,6 +25,10 @@ contract ImpactEvaluatorTest is Test {
         assertEq(impactEvaluator.currentRoundIndex(), 1);
         assertEq(impactEvaluator.getRound(0).exists, false);
         assertEq(impactEvaluator.getRound(1).exists, true);
+        impactEvaluator.setMaxStoredRounds(1000);
+        impactEvaluator.adminAdvanceRound();
+        assertEq(impactEvaluator.getRound(0).exists, false);
+        assertEq(impactEvaluator.getRound(1).exists, true);
     }
 
     function test_SetNextRoundLength() public {

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -18,6 +18,15 @@ contract ImpactEvaluatorTest is Test {
         assertEq(impactEvaluator.currentRoundIndex(), 1);
     }
 
+    function test_AdvanceRoundCleanup() public {
+        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        impactEvaluator.setMaxStoredRounds(1);
+        impactEvaluator.adminAdvanceRound();
+        assertEq(impactEvaluator.currentRoundIndex(), 1);
+        assertEq(impactEvaluator.getRound(0).exists, false);
+        assertEq(impactEvaluator.getRound(1).exists, true);
+    }
+
     function test_SetNextRoundLength() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
         assertEq(impactEvaluator.getRound(0).end, block.number + 10);

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -29,6 +29,11 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.adminAdvanceRound();
         assertEq(impactEvaluator.getRound(0).exists, false);
         assertEq(impactEvaluator.getRound(1).exists, true);
+        assertEq(impactEvaluator.getRound(2).exists, true);
+        impactEvaluator.setMaxStoredRounds(1);
+        assertEq(impactEvaluator.getRound(0).exists, false);
+        assertEq(impactEvaluator.getRound(1).exists, false);
+        assertEq(impactEvaluator.getRound(2).exists, true);
     }
 
     function test_SetNextRoundLength() public {


### PR DESCRIPTION
Limits storage of rounds to 1000 (configurable), so that storage-related gas cost doesn't grow indefinitely.

Clean up happens in two places:
1. When creating rounds. Here we delete one round if we know we are at our limit and every new round leads to deletion of the oldest round. This has constant gas cost, advancing a round shouldn't create surprises. This is especially important since the gas cost for advancing a round will be paid by the party submitting metrics to `measure()`, which shouldn't have to pay for a migration.
2. When lowering the `maxStoredRounds` value. Here we potentially clean up many rounds, if the new value is lower than the current value. This has variable gas cost, but is an admin method so it is ok.

Closes #10