### PR TITLE
Refactor round storage

### DIFF
--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -83,9 +83,7 @@ contract ImpactEvaluator is AccessControl {
         Round storage round = rounds[roundIndex];
         require(!round.scoresSubmitted, "Scores already submitted");
         for (uint i = 0; i < addresses.length; i++) {
-            address addr = addresses[i];
-            uint score = scores[i];
-            round.scores[addr] = score;
+            round.scores[addresses[i]] = scores[i];
         }
         round.summaryText = summaryText;
         round.scoresSubmitted = true;

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -80,14 +80,15 @@ contract ImpactEvaluator is AccessControl {
             addresses.length == scores.length,
             "Addresses and scores length mismatch"
         );
-        require(!rounds[roundIndex].scoresSubmitted, "Scores already submitted");
+        Round storage round = rounds[roundIndex];
+        require(!round.scoresSubmitted, "Scores already submitted");
         for (uint i = 0; i < addresses.length; i++) {
             address addr = addresses[i];
             uint score = scores[i];
-            rounds[roundIndex].scores[addr] = score;
+            round.scores[addr] = score;
         }
-        rounds[roundIndex].summaryText = summaryText;
-        rounds[roundIndex].scoresSubmitted = true;
+        round.summaryText = summaryText;
+        round.scoresSubmitted = true;
         if (scores.length > 0) {
             reward(addresses, scores);
         }

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -12,7 +12,7 @@ contract ImpactEvaluatorTest is Test {
     function test_AdvanceRound() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
         assertEq(impactEvaluator.currentRoundIndex(), 0);
-        assertEq(impactEvaluator.getRound(0).end, block.number + 10);
+        assertEq(impactEvaluator.getRoundEnd(0), block.number + 10);
         vm.expectEmit(false, false, false, true);
         emit RoundStart(1);
         impactEvaluator.adminAdvanceRound();
@@ -21,11 +21,11 @@ contract ImpactEvaluatorTest is Test {
 
     function test_SetNextRoundLength() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
-        assertEq(impactEvaluator.getRound(0).end, block.number + 10);
+        assertEq(impactEvaluator.getRoundEnd(0), block.number + 10);
         impactEvaluator.setNextRoundLength(20);
-        assertEq(impactEvaluator.getRound(0).end, block.number + 10);
+        assertEq(impactEvaluator.getRoundEnd(0), block.number + 10);
         impactEvaluator.adminAdvanceRound();
-        assertEq(impactEvaluator.getRound(1).end, block.number + 20);
+        assertEq(impactEvaluator.getRoundEnd(1), block.number + 20);
     }
 
     function test_setRoundReward() public {
@@ -43,13 +43,13 @@ contract ImpactEvaluatorTest is Test {
 
     function test_AddMeasurements() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(0x1));
-        assertEq(impactEvaluator.getRound(0).measurementsCids.length, 0);
+        assertEq(impactEvaluator.getRoundMeasurementsCids(0).length, 0);
         vm.expectEmit(false, false, false, true);
         emit MeasurementsAdded("cid", 0);
         uint roundIndex = impactEvaluator.addMeasurements("cid");
         assertEq(roundIndex, 0);
-        assertEq(impactEvaluator.getRound(0).measurementsCids.length, 1);
-        assertEq(impactEvaluator.getRound(0).measurementsCids[0], "cid");
+        assertEq(impactEvaluator.getRoundMeasurementsCids(0).length, 1);
+        assertEq(impactEvaluator.getRoundMeasurementsCids(0)[0], "cid");
     }
 
     function test_SetScoresNotEvaluator() public {
@@ -99,13 +99,9 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.setScores(0, addresses, scores, "1 task performed");
         assertEq(addresses[0].balance, 100);
 
-        ImpactEvaluator.Round memory round = impactEvaluator.getRound(0);
-        assertEq(round.participants.length, 1);
-        assertEq(round.scores.length, 1);
-        assertEq(round.participants[0], addresses[0]);
-        assertEq(round.scores[0], scores[0]);
-        assertEq(round.summaryText, "1 task performed");
-        assertEq(round.scoresSubmitted, true);
+        assertEq(impactEvaluator.getParticipantScore(0, addresses[0]), scores[0]);
+        assertEq(impactEvaluator.getRoundSummaryText(0), "1 task performed");
+        assertEq(impactEvaluator.getRoundScoresSubmitted(0), true);
 
         vm.expectRevert("Scores already submitted");
         impactEvaluator.setScores(0, addresses, scores, "1 task performed");


### PR DESCRIPTION
Motivation:

https://www.notion.so/IE-Contract-Spec-58ba83cc5f6e4af79ee0ebcdb3a178ba?d=5d7f026acac54c46b9f0e093547c812f&pvs=4#ec3d5ac273f74badba701374f5ba19dd
> Synced with Julian Gruber and we agree this should be turned into a mapping so we can add getters for participant info

This allows participants to fetch their score in a round without having to iterate over all participants' scores