### PR TITLE
Add allow multiple setScores calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Evaluator functions
 
-### `.setScores(uint roundIndex, address payable[] addresses, uint[] scores, string summaryText)`
+### `.setScores(uint roundIndex, address payable[] addresses, uint[] scores, uint callNumber, uint totalCalls)`
 
 ## Admin functions
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Evaluator functions
 
-### `.setScores(uint roundIndex, address payable[] addresses, uint[] scores, uint callNumber, uint totalCalls)`
+### `.setScores(uint roundIndex, address payable[] addresses, uint[] scores, bool moreScoresExpected)`
 
 ## Admin functions
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -153,6 +153,10 @@ contract ImpactEvaluator is AccessControl {
         return rounds[roundIndex].scores[participant];
     }
 
+    function getRoundScoresSubmitted(uint index) public view returns (bool) {
+        return rounds[index].scoresSubmitted;
+    }
+
     function getRoundExists(uint index) public view returns (bool) {
         return rounds[index].exists;
     }

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -146,15 +146,15 @@ contract ImpactEvaluator is AccessControl {
         return rounds[index].measurementsCids;
     }
 
+    function getRoundScoresSubmitted(uint index) public view returns (bool) {
+        return rounds[index].scoresSubmitted;
+    }
+
     function getParticipantScore(
         uint roundIndex,
         address participant
     ) public view returns (uint) {
         return rounds[roundIndex].scores[participant];
-    }
-
-    function getRoundScoresSubmitted(uint index) public view returns (bool) {
-        return rounds[index].scoresSubmitted;
     }
 
     function getRoundExists(uint index) public view returns (bool) {

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -77,8 +77,7 @@ contract ImpactEvaluatorTest is Test {
             0,
             new address payable[](0),
             new uint64[](0),
-            0,
-            1
+            false
         );
     }
 
@@ -94,8 +93,7 @@ contract ImpactEvaluatorTest is Test {
             0,
             new address payable[](1),
             new uint64[](0),
-            0,
-            1
+            false
         );
 
         address payable[] memory addresses = new address payable[](1);
@@ -105,13 +103,13 @@ contract ImpactEvaluatorTest is Test {
         vm.deal(payable(address(impactEvaluator)), 100 ether);
         vm.expectEmit(false, false, false, true);
         emit Transfer(addresses[0], 100 ether);
-        impactEvaluator.setScores(0, addresses, scores, 0, 1);
+        impactEvaluator.setScores(0, addresses, scores, false);
         assertEq(addresses[0].balance, 100 ether, "correct balance");
 
         assertEq(impactEvaluator.getParticipantScore(0, addresses[0]), scores[0]);
 
-        vm.expectRevert("Call number already used");
-        impactEvaluator.setScores(0, addresses, scores, 0, 1);
+        vm.expectRevert("Scores already submitted");
+        impactEvaluator.setScores(0, addresses, scores, false);
     }
 
     function test_SetScoresMultipleParticipants() public {
@@ -128,7 +126,7 @@ contract ImpactEvaluatorTest is Test {
         scores[1] = 25e13;
         scores[2] = 25e13;
         vm.deal(payable(address(impactEvaluator)), 100 ether);
-        impactEvaluator.setScores(0, addresses, scores, 0, 1);
+        impactEvaluator.setScores(0, addresses, scores, false);
         assertEq(addresses[0].balance, 50 ether, "addresses[0] balance");
         assertEq(addresses[1].balance, 25 ether);
         assertEq(addresses[2].balance, 25 ether);
@@ -149,7 +147,7 @@ contract ImpactEvaluatorTest is Test {
         emit Transfer(addresses[0], 100 ether - 1e5);
         vm.expectEmit(false, false, false, true);
         emit Transfer(addresses[0], 1e5);
-        impactEvaluator.setScores(0, addresses, scores, 0, 1);
+        impactEvaluator.setScores(0, addresses, scores, false);
         assertEq(addresses[0].balance, 100 ether - 1e5, "addresses[0] balance");
         assertEq(addresses[1].balance, 1e5, "addresses[1] balance");
     }
@@ -161,7 +159,7 @@ contract ImpactEvaluatorTest is Test {
         address payable[] memory addresses = new address payable[](0);
         uint64[] memory scores = new uint64[](0);
         vm.deal(payable(address(impactEvaluator)), 100 ether);
-        impactEvaluator.setScores(0, addresses, scores, 0, 1);
+        impactEvaluator.setScores(0, addresses, scores, false);
     }
 
     function test_SetScoresMultipleCalls() public {
@@ -171,11 +169,11 @@ contract ImpactEvaluatorTest is Test {
         addresses[0] = payable(vm.addr(1));
         uint64[] memory scores = new uint64[](1);
         scores[0] = 1e15 - 1;
-        impactEvaluator.setScores(0, addresses, scores, 0, 2);
+        impactEvaluator.setScores(0, addresses, scores, true);
         addresses[0] = payable(vm.addr(2));
         scores[0] = 1;
         vm.deal(payable(address(impactEvaluator)), 100 ether);
-        impactEvaluator.setScores(0, addresses, scores, 1, 2);
+        impactEvaluator.setScores(0, addresses, scores, false);
         assertEq(vm.addr(1).balance, 100 ether - 1e5, "vm.addr(1) balance");
         assertEq(vm.addr(2).balance, 1e5, "vm.addr(2) balance");
     }

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -77,7 +77,8 @@ contract ImpactEvaluatorTest is Test {
             0,
             new address payable[](0),
             new uint64[](0),
-            "no measurements"
+            0,
+            1
         );
     }
 
@@ -93,7 +94,8 @@ contract ImpactEvaluatorTest is Test {
             0,
             new address payable[](1),
             new uint64[](0),
-            "one peer"
+            0,
+            1
         );
 
         address payable[] memory addresses = new address payable[](1);
@@ -103,15 +105,15 @@ contract ImpactEvaluatorTest is Test {
         vm.deal(payable(address(impactEvaluator)), 100 ether);
         vm.expectEmit(false, false, false, true);
         emit Transfer(addresses[0], 100 ether);
-        impactEvaluator.setScores(0, addresses, scores, "1 task performed");
+        impactEvaluator.setScores(0, addresses, scores, 0, 1);
         assertEq(addresses[0].balance, 100 ether, "correct balance");
 
         assertEq(impactEvaluator.getParticipantScore(0, addresses[0]), scores[0]);
-        assertEq(impactEvaluator.getRoundSummaryText(0), "1 task performed");
-        assertEq(impactEvaluator.getRoundScoresSubmitted(0), true);
+        assertEq(impactEvaluator.getRoundScoresSubmitted(0).length, 1);
+        assertEq(impactEvaluator.getRoundScoresSubmitted(0)[0], 0);
 
-        vm.expectRevert("Scores already submitted");
-        impactEvaluator.setScores(0, addresses, scores, "1 task performed");
+        vm.expectRevert("Call number already used");
+        impactEvaluator.setScores(0, addresses, scores, 0, 1);
     }
 
     function test_SetScoresMultipleParticipants() public {
@@ -128,7 +130,7 @@ contract ImpactEvaluatorTest is Test {
         scores[1] = 25e13;
         scores[2] = 25e13;
         vm.deal(payable(address(impactEvaluator)), 100 ether);
-        impactEvaluator.setScores(0, addresses, scores, "some task performed");
+        impactEvaluator.setScores(0, addresses, scores, 0, 1);
         assertEq(addresses[0].balance, 50 ether, "addresses[0] balance");
         assertEq(addresses[1].balance, 25 ether);
         assertEq(addresses[2].balance, 25 ether);
@@ -149,7 +151,7 @@ contract ImpactEvaluatorTest is Test {
         emit Transfer(addresses[0], 100 ether - 1e5);
         vm.expectEmit(false, false, false, true);
         emit Transfer(addresses[0], 1e5);
-        impactEvaluator.setScores(0, addresses, scores, "2 tasks performed");
+        impactEvaluator.setScores(0, addresses, scores, 0, 1);
         assertEq(addresses[0].balance, 100 ether - 1e5, "addresses[0] balance");
         assertEq(addresses[1].balance, 1e5, "addresses[1] balance");
     }
@@ -161,7 +163,7 @@ contract ImpactEvaluatorTest is Test {
         address payable[] memory addresses = new address payable[](0);
         uint64[] memory scores = new uint64[](0);
         vm.deal(payable(address(impactEvaluator)), 100 ether);
-        impactEvaluator.setScores(0, addresses, scores, "0 tasks performed");
+        impactEvaluator.setScores(0, addresses, scores, 0, 1);
     }
 
     function test_CurrentRoundMeasurementCount() public {

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -106,7 +106,11 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.setScores(0, addresses, scores, false);
         assertEq(addresses[0].balance, 100 ether, "correct balance");
 
-        assertEq(impactEvaluator.getParticipantScore(0, addresses[0]), scores[0]);
+        assertEq(
+            impactEvaluator.getParticipantScore(0, addresses[0]),
+            scores[0],
+            "participant score"
+        );
         assertEq(impactEvaluator.getRoundScoresSubmitted(0), true);
 
         vm.expectRevert("Scores already submitted");

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -109,8 +109,6 @@ contract ImpactEvaluatorTest is Test {
         assertEq(addresses[0].balance, 100 ether, "correct balance");
 
         assertEq(impactEvaluator.getParticipantScore(0, addresses[0]), scores[0]);
-        assertEq(impactEvaluator.getRoundScoresSubmitted(0).length, 1);
-        assertEq(impactEvaluator.getRoundScoresSubmitted(0)[0], 0);
 
         vm.expectRevert("Call number already used");
         impactEvaluator.setScores(0, addresses, scores, 0, 1);
@@ -164,6 +162,22 @@ contract ImpactEvaluatorTest is Test {
         uint64[] memory scores = new uint64[](0);
         vm.deal(payable(address(impactEvaluator)), 100 ether);
         impactEvaluator.setScores(0, addresses, scores, 0, 1);
+    }
+
+    function test_SetScoresMultipleCalls() public {
+        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        impactEvaluator.adminAdvanceRound();
+        address payable[] memory addresses = new address payable[](1);
+        addresses[0] = payable(vm.addr(1));
+        uint64[] memory scores = new uint64[](1);
+        scores[0] = 1e15 - 1;
+        impactEvaluator.setScores(0, addresses, scores, 0, 2);
+        addresses[0] = payable(vm.addr(2));
+        scores[0] = 1;
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
+        impactEvaluator.setScores(0, addresses, scores, 1, 2);
+        assertEq(vm.addr(1).balance, 100 ether - 1e5, "vm.addr(1) balance");
+        assertEq(vm.addr(2).balance, 1e5, "vm.addr(2) balance");
     }
 
     function test_CurrentRoundMeasurementCount() public {

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -107,6 +107,7 @@ contract ImpactEvaluatorTest is Test {
         assertEq(addresses[0].balance, 100 ether, "correct balance");
 
         assertEq(impactEvaluator.getParticipantScore(0, addresses[0]), scores[0]);
+        assertEq(impactEvaluator.getRoundScoresSubmitted(0), true);
 
         vm.expectRevert("Scores already submitted");
         impactEvaluator.setScores(0, addresses, scores, false);


### PR DESCRIPTION
This allows `setScores` to be called multiple times per round, which can be required if the participant set = arguments length gets too large.

I've also removed `summaryText`, since we don't have a real need for it, and it's not worth the storage discussion.