### PR TITLE
Minimize storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Evaluator functions
 
-### `.setScores(uint roundIndex, address payable[] addresses, uint[] scores, string summaryText)`
+### `.setScores(uint roundIndex, address payable[] addresses, uint[] scores)`
 
 ## Admin functions
 
@@ -20,9 +20,6 @@
 ## Getters / Views
 
 ### `.currentRoundIndex() -> uint`
-### `.getRound(uint index) -> Round`
-### `.currentRoundMeasurementCount() -> uint`
-### `.rounds()`
 ### `.nextRoundLength()`
 ### `.roundReward()`
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -100,7 +100,7 @@ contract ImpactEvaluator is AccessControl {
                 uint64[] memory mergedScores
             ) = mergeScores(round, addresses, scores);
             reward(mergedAddresses, mergedScores);
-            cleanUpRound(roundIndex);
+            cleanUpRound(round, roundIndex);
         }
     }
 
@@ -125,8 +125,7 @@ contract ImpactEvaluator is AccessControl {
         return (mergedAddresses, mergedScores);
     }
 
-    function cleanUpRound(uint roundIndex) private {
-        Round storage round = openRounds[roundIndex];
+    function cleanUpRound(Round storage round, uint roundIndex) private {
         round.end = 0;
         delete round.addresses;
         delete round.scores;

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -80,6 +80,9 @@ contract ImpactEvaluator is AccessControl {
         Round storage round = openRounds[roundIndex];
         require(round.exists, "Open round does not exist");
         reward(addresses, scores);
+
+        round.end = 0;
+        round.exists = false;
         delete openRounds[roundIndex];
     }
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -95,15 +95,11 @@ contract ImpactEvaluator is AccessControl {
                 round.scores.push(scores[i]);
             }
         } else {
-            if (round.addresses.length > 0) {
-                (
-                    address payable[] memory mergedAddresses,
-                    uint64[] memory mergedScores
-                ) = mergeScores(round, addresses, scores);
-                reward(mergedAddresses, mergedScores);
-            } else {
-                reward(addresses, scores);
-            }
+            (
+                address payable[] memory mergedAddresses,
+                uint64[] memory mergedScores
+            ) = mergeScores(round, addresses, scores);
+            reward(mergedAddresses, mergedScores);
             cleanUpRound(roundIndex);
         }
     }

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -24,30 +24,32 @@ contract ImpactEvaluator is AccessControl {
     constructor(address admin) {
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         _grantRole(EVALUATE_ROLE, admin);
-        advanceRound(true);
+        initializeCurrentRound();
     }
 
     receive() external payable {}
 
-    function advanceRound(bool firstRound) private {
-        if (!firstRound) {
-            currentRoundIndex++;
-        }
+    function initializeCurrentRound() private {
         Round storage round = openRounds[currentRoundIndex];
         round.end = block.number + nextRoundLength;
         round.exists = true;
         emit RoundStart(currentRoundIndex);
     }
 
+    function advanceRound() private {
+        currentRoundIndex++;
+        initializeCurrentRound();
+    }
+
     function adminAdvanceRound() public {
         require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not an admin");
-        advanceRound(false);
+        advanceRound();
     }
 
     function maybeAdvanceRound() private {
         uint currentRoundEnd = openRounds[currentRoundIndex].end;
         if (block.number >= currentRoundEnd) {
-            advanceRound(false);
+            advanceRound();
         }
     }
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.19;
 contract ImpactEvaluator is AccessControl {
     struct Round {
         uint end;
-        string[] measurementsCids;
         bool exists;
     }
 
@@ -64,7 +63,6 @@ contract ImpactEvaluator is AccessControl {
 
     function addMeasurements(string memory cid) public returns (uint) {
         maybeAdvanceRound();
-        openRounds[currentRoundIndex].measurementsCids.push(cid);
         emit MeasurementsAdded(cid, currentRoundIndex, msg.sender);
         return currentRoundIndex;
     }
@@ -100,9 +98,5 @@ contract ImpactEvaluator is AccessControl {
                 emit TransferFailed(addr, amount);
             }
         }
-    }
-
-    function currentRoundMeasurementCount() public view returns (uint) {
-        return openRounds[currentRoundIndex].measurementsCids.length;
     }
 }

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -96,26 +96,37 @@ contract ImpactEvaluator is AccessControl {
             }
         } else {
             if (round.addresses.length > 0) {
-                uint mergedLength = round.addresses.length + addresses.length;
-                address payable[]
-                    memory mergedAddresses = new address payable[](
-                        mergedLength
-                    );
-                uint64[] memory mergedScores = new uint64[](mergedLength);
-                for (uint i = 0; i < round.addresses.length; i++) {
-                    mergedAddresses[i] = round.addresses[i];
-                    mergedScores[i] = round.scores[i];
-                }
-                for (uint i = 0; i < addresses.length; i++) {
-                    mergedAddresses[round.addresses.length + i] = addresses[i];
-                    mergedScores[round.addresses.length + i] = scores[i];
-                }
+                (
+                    address payable[] memory mergedAddresses,
+                    uint64[] memory mergedScores
+                ) = mergeScores(round, addresses, scores);
                 reward(mergedAddresses, mergedScores);
             } else {
                 reward(addresses, scores);
             }
             cleanUpRound(roundIndex);
         }
+    }
+
+    function mergeScores(
+        Round storage round,
+        address payable[] memory addresses,
+        uint64[] memory scores
+    ) private view returns (address payable[] memory, uint64[] memory) {
+        uint mergedLength = round.addresses.length + addresses.length;
+        address payable[] memory mergedAddresses = new address payable[](
+            mergedLength
+        );
+        uint64[] memory mergedScores = new uint64[](mergedLength);
+        for (uint i = 0; i < round.addresses.length; i++) {
+            mergedAddresses[i] = round.addresses[i];
+            mergedScores[i] = round.scores[i];
+        }
+        for (uint i = 0; i < addresses.length; i++) {
+            mergedAddresses[round.addresses.length + i] = addresses[i];
+            mergedScores[round.addresses.length + i] = scores[i];
+        }
+        return (mergedAddresses, mergedScores);
     }
 
     function cleanUpRound(uint roundIndex) private {

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -47,12 +47,10 @@ contract ImpactEvaluatorTest is Test {
 
     function test_AddMeasurements() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(0x1));
-        assertEq(impactEvaluator.currentRoundMeasurementCount(), 0);
         vm.expectEmit(false, false, false, true);
         emit MeasurementsAdded("cid", 0, address(this));
         uint roundIndex = impactEvaluator.addMeasurements("cid");
         assertEq(roundIndex, 0);
-        assertEq(impactEvaluator.currentRoundMeasurementCount(), 1);
     }
 
     function test_SetScoresNotEvaluator() public {
@@ -141,14 +139,5 @@ contract ImpactEvaluatorTest is Test {
         uint64[] memory scores = new uint64[](0);
         vm.deal(payable(address(impactEvaluator)), 100 ether);
         impactEvaluator.setScores(0, addresses, scores);
-    }
-
-    function test_CurrentRoundMeasurementCount() public {
-        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
-        assertEq(impactEvaluator.currentRoundMeasurementCount(), 0);
-        impactEvaluator.addMeasurements("cid");
-        assertEq(impactEvaluator.currentRoundMeasurementCount(), 1);
-        impactEvaluator.adminAdvanceRound();
-        assertEq(impactEvaluator.currentRoundMeasurementCount(), 0);
     }
 }


### PR DESCRIPTION
This "radical" PR removes as much internal storage as possible, relying on Events as a method of cost saving and also reducing complexity. See gas comparison, before:

```
[PASS] test_AddMeasurements() (gas: 1911384)
[PASS] test_AdvanceRound() (gas: 1901709)
[PASS] test_SetNextRoundLength() (gas: 1899204)
[PASS] test_SetScores() (gas: 2007204)
[PASS] test_SetScoresEmptyRound() (gas: 1945811)
[PASS] test_SetScoresFractions() (gas: 2069759)
[PASS] test_SetScoresMultipleParticipants() (gas: 2125921)
[PASS] test_SetScoresNotEvaluator() (gas: 1855247)
[PASS] test_setRoundReward() (gas: 1850238)
[PASS] test_setRoundRewardNotAdmin() (gas: 1853482)
```

after:

```
[PASS] test_AddMeasurements() (gas: 1166367)
[PASS] test_AdvanceRound() (gas: 1230516)
[PASS] test_SetNextRoundLength() (gas: 1228349)
[PASS] test_SetScores() (gas: 1222263)
[PASS] test_SetScoresEmptyRound() (gas: 1190229)
[PASS] test_SetScoresFractions() (gas: 1269296)
[PASS] test_SetScoresMultipleParticipants() (gas: 1302958)
[PASS] test_SetScoresNotEvaluator() (gas: 1164214)
[PASS] test_setRoundReward() (gas: 1159622)
[PASS] test_setRoundRewardNotAdmin() (gas: 1162977)
```

In some calls, this is almost a 50% cost reduction. And since we only keep track of the current open rounds (ie rounds that have started but for which evaluation results haven't been submitted yet), which should on average just be 2, the contract's state won't grow.

Unless I missed something, the only impact this will have on our current running system is that we can't track per-round measurement count from the IE any more. This shouldn't be a problem, as we also have this state in the measurement and evaluate services. Listening for and querying events is already the main method of getting data out of the system. I also removed the method `getParticipantScores`, if a participant wants to see their score in a round they can look up the matching `setScores()` transaction.