### PR TITLE
Allow infinite participants by not storing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 ### `.adminAdvanceRound()`
 
+### `.adminDeleteRound(uint openRoundIndex)`
+
 ### `.setNextRoundLength(uint nextRoundLength)`
 
 ### `.setRoundReward(uint roundReward)`

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@
 
 ### `.currentRoundIndex() -> uint`
 
-### `.nextRoundLength()`
+### `.nextRoundLength() -> uint`
 
-### `.roundReward()`
+### `.roundReward() -> uint`
+
+### `.getOpenRoundIndexes() -> uint[]`
 
 ## Roles
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -121,6 +121,7 @@ contract ImpactEvaluator is AccessControl {
     }
 
     function adminDeleteRound(uint roundIndex) public onlyAdmin {
+        require(roundIndex < currentRoundIndex, "Round not finished");
         deleteRound(roundIndex);
     }
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -120,6 +120,10 @@ contract ImpactEvaluator is AccessControl {
         openRoundIndexes.pop();
     }
 
+    function adminDeleteRound(uint roundIndex) public onlyAdmin {
+        deleteRound(roundIndex);
+    }
+
     function validateScores(
         uint64[] memory scores,
         uint scoresAlreadySubmitted

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -92,7 +92,7 @@ contract ImpactEvaluator is AccessControl {
         round.totalScores += sumOfScores;
 
         if (round.totalScores == MAX_SCORE) {
-            cleanUpRound(round, roundIndex);
+            delete openRounds[roundIndex];
         }
     }
 
@@ -137,13 +137,6 @@ contract ImpactEvaluator is AccessControl {
                 emit TransferFailed(addr, amount);
             }
         }
-    }
-
-    function cleanUpRound(Round storage round, uint roundIndex) private {
-        round.end = 0;
-        round.totalScores = 0;
-        round.exists = false;
-        delete openRounds[roundIndex];
     }
 
     modifier onlyAdmin() {

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -16,6 +16,7 @@ contract ImpactEvaluator is AccessControl {
     uint public nextRoundLength = 10;
     uint public roundReward = 100 ether;
     uint64 public constant MAX_SCORE = 1e15;
+    uint public constant MAX_SCORES_PER_ROUND = 200000;
 
     event MeasurementsAdded(
         string cid,
@@ -84,9 +85,18 @@ contract ImpactEvaluator is AccessControl {
             "Addresses and scores length mismatch"
         );
         require(roundIndex < currentRoundIndex, "Round not finished");
+        require(
+            addresses.length <= MAX_SCORES_PER_ROUND,
+            "Too many scores submitted"
+        );
 
         Round storage round = openRounds[roundIndex];
         require(round.exists, "Open round does not exist");
+
+        require(
+            addresses.length + round.addresses.length <= MAX_SCORES_PER_ROUND,
+            "Too many scores submitted"
+        );
 
         for (uint i = 0; i < addresses.length; i++) {
             round.addresses.push(addresses[i]);

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -234,5 +234,11 @@ contract ImpactEvaluatorTest is Test {
         openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
         assertEq(openRoundIndexes.length, 1, "one open round index");
         assertEq(openRoundIndexes[0], 1, "round 1");
+
+        impactEvaluator.adminAdvanceRound();
+        impactEvaluator.adminDeleteRound(1);
+        openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
+        assertEq(openRoundIndexes.length, 1, "one open round index");
+        assertEq(openRoundIndexes[0], 2, "round 2");
     }
 }

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -241,4 +241,17 @@ contract ImpactEvaluatorTest is Test {
         assertEq(openRoundIndexes.length, 1, "one open round index");
         assertEq(openRoundIndexes[0], 2, "round 2");
     }
+
+    function test_AdminDeleteRound() public {
+        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(vm.addr(1)));
+        vm.expectRevert("Not an admin");
+        impactEvaluator.adminDeleteRound(0);
+
+        impactEvaluator = new ImpactEvaluator(address(this));
+        vm.expectRevert("Round not finished");
+        impactEvaluator.adminDeleteRound(0);
+
+        impactEvaluator.adminAdvanceRound();
+        impactEvaluator.adminDeleteRound(0);
+    }
 }

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -179,7 +179,9 @@ contract ImpactEvaluatorTest is Test {
         vm.deal(payable(address(impactEvaluator)), 100 ether);
 
         // The most scores we can submit to one round before running out of gas
-        uint64 totalParticipants = uint64(impactEvaluator.MAX_SCORES_PER_ROUND());
+        uint64 totalParticipants = uint64(
+            impactEvaluator.MAX_SCORES_PER_ROUND()
+        );
         // With all scores in one call we also run out of gas
         uint64 calls = 2;
         for (uint j = 0; j < calls; j++) {
@@ -203,9 +205,13 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.adminAdvanceRound();
         vm.deal(payable(address(impactEvaluator)), 100 ether);
 
-        uint64 totalParticipants = uint64(impactEvaluator.MAX_SCORES_PER_ROUND()) * 2;
-        uint64 calls = 12;
-        uint64 failingCall = 6;
+        uint64 totalParticipants = uint64(
+            impactEvaluator.MAX_SCORES_PER_ROUND()
+        ) * 2;
+        // With too many scores per round we run out of gas submitting them
+        // before the limit is reached
+        uint64 calls = 6;
+        uint64 failingCall = 3;
         for (uint j = 0; j < failingCall; j++) {
             uint participants = totalParticipants / calls;
             address payable[] memory addresses = new address payable[](

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -189,6 +189,21 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.setScores(0, addresses, scores);
     }
 
+    function test_SetScoresOverflow() public {
+        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        impactEvaluator.adminAdvanceRound();
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
+
+        address payable[] memory addresses = new address payable[](2);
+        uint64[] memory scores = new uint64[](2);
+        addresses[0] = payable(vm.addr(1));
+        addresses[1] = payable(vm.addr(1));
+        scores[0] = 2**64 - 1;
+        scores[1] = 1;
+        vm.expectRevert();
+        impactEvaluator.setScores(0, addresses, scores);
+    }
+
     function test_SetScoresUnfinishedRound() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
         address payable[] memory addresses = new address payable[](0);

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -211,4 +211,28 @@ contract ImpactEvaluatorTest is Test {
         vm.expectRevert("Round not finished");
         impactEvaluator.setScores(0, addresses, scores);
     }
+
+    function test_OpenRoundIndexes() public {
+        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
+        
+        uint[] memory openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
+        assertEq(openRoundIndexes.length, 1, "one open round index");
+        assertEq(openRoundIndexes[0], 0, "round 0");
+
+        impactEvaluator.adminAdvanceRound();
+        openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
+        assertEq(openRoundIndexes.length, 2, "two open round index");
+        assertEq(openRoundIndexes[1], 1, "round 1");
+
+        address payable[] memory addresses = new address payable[](1);
+        uint64[] memory scores = new uint64[](1);
+        addresses[0] = payable(vm.addr(1));
+        scores[0] = impactEvaluator.MAX_SCORE();
+        impactEvaluator.setScores(0, addresses, scores);
+
+        openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
+        assertEq(openRoundIndexes.length, 1, "one open round index");
+        assertEq(openRoundIndexes[0], 1, "round 1");
+    }
 }


### PR DESCRIPTION
<del>Prevent the contract from becoming dysfunctional by limiting the total number of participants per round.

<del>When the limit is reached, no new scores will be accepted. This is a problem, because then the round will never finish -> rewards will never be paid and the round stays in contract storage. I'm inclined to count rounds with too many participants as invalid, and not pay anything. This is an attack vector, but it's somewhat fair, since everyone gets paid the same in this case. Another option is to randomly pick participants that make it and ignore the rest. This way you can't attack the contract leading to no pay outs. Otoh, if you swarm it with too many nodes, you increase the chances of you receiving the majority of payouts.

<del>The limit is set to 200k participants currently.</del>

This PR changes the strategy to have multiple reward calls, one per evaluation share submitted. This way, round scores / addresses don't need to be stored at all, which was previously the case as only once all had been submitted we called reward(). I think I'll try that next.

This again reduces gas cost notably.

Before:

```
[PASS] test_AddMeasurements() (gas: 1462378)
[PASS] test_AdvanceRound() (gas: 1526346)
[PASS] test_SetNextRoundLength() (gas: 1527995)
[PASS] test_SetScores() (gas: 1532795)
[PASS] test_SetScoresEmptyRound() (gas: 1527475)
[PASS] test_SetScoresFractions() (gas: 1584622)
[PASS] test_SetScoresMultipleCalls() (gas: 1990782)
[PASS] test_SetScoresMultipleParticipants() (gas: 1622395)
[PASS] test_SetScoresNotEvaluator() (gas: 1460011)
[PASS] test_SetScoresTooBig() (gas: 1618884)
[PASS] test_SetScoresUnfinishedRound() (gas: 1458138)
[PASS] test_setRoundReward() (gas: 1455441)
[PASS] test_setRoundRewardNotAdmin() (gas: 1458796)
```

After:

```
[PASS] test_AddMeasurements() (gas: 1371968)
[PASS] test_AdvanceRound() (gas: 1438075)
[PASS] test_SetNextRoundLength() (gas: 1442070)
[PASS] test_SetScores() (gas: 1432273)
[PASS] test_SetScoresEmptyRound() (gas: 1437637)
[PASS] test_SetScoresFractions() (gas: 1479858)
[PASS] test_SetScoresMultipleCalls() (gas: 1829204)
[PASS] test_SetScoresMultipleParticipants() (gas: 1513397)
[PASS] test_SetScoresNotEvaluator() (gas: 1369601)
[PASS] test_SetScoresTooBig() (gas: 1439384)
[PASS] test_SetScoresUnfinishedRound() (gas: 1367728)
[PASS] test_setRoundReward() (gas: 1365031)
[PASS] test_setRoundRewardNotAdmin() (gas: 1368386)
```

After this PR, storage is _not_ unbounded any more 🥳  (Except for open unevaluated rounds)

The diff is larger, I suggest to focus on reading the resulting source code https://github.com/Meridian-IE/impact-evaluator/blob/e6b44b7bb659be5eaa7f6337867c7325e07dc3b0/src/ImpactEvaluator.sol.

If there are too many participants, gas costs could still explode - but for the evaluator and not the contract itself. Therefore we should add safeguards there.