### PR TITLE
Refactor round store array

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ will be called and the round finishes.
 
 ### `.roundReward() -> uint`
 
-### `.getOpenRoundIndexes() -> uint[]`
-
 ## Roles
 
 ### `.EVALUATE_ROLE()`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ will be called and the round finishes.
 
 ### `.adminAdvanceRound()`
 
+### `.adminDeleteRound(uint openRoundIndex)`
+
 ### `.setNextRoundLength(uint nextRoundLength)`
 
 ### `.setRoundReward(uint roundReward)`
@@ -27,9 +29,11 @@ will be called and the round finishes.
 
 ### `.currentRoundIndex() -> uint`
 
-### `.nextRoundLength()`
+### `.nextRoundLength() -> uint`
 
-### `.roundReward()`
+### `.roundReward() -> uint`
+
+### `.getOpenRoundIndexes() -> uint[]`
 
 ## Roles
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -6,12 +6,12 @@ pragma solidity ^0.8.19;
 contract ImpactEvaluator is AccessControl {
     struct Round {
         uint end;
-        address payable[] addresses;
-        uint64[] scores;
         bool exists;
+        uint totalScores;
     }
 
     mapping(uint => Round) public openRounds;
+    uint[] public openRoundIndexes;
     uint public currentRoundIndex;
     uint public nextRoundLength = 10;
     uint public roundReward = 100 ether;
@@ -40,6 +40,7 @@ contract ImpactEvaluator is AccessControl {
         Round storage round = openRounds[currentRoundIndex];
         round.end = block.number + nextRoundLength;
         round.exists = true;
+        openRoundIndexes.push(currentRoundIndex);
         emit RoundStart(currentRoundIndex);
     }
 
@@ -88,45 +89,77 @@ contract ImpactEvaluator is AccessControl {
         Round storage round = openRounds[roundIndex];
         require(round.exists, "Open round does not exist");
 
-        for (uint i = 0; i < addresses.length; i++) {
-            round.addresses.push(addresses[i]);
-            round.scores.push(scores[i]);
-        }
+        uint sumOfScores = validateScores(scores, round.totalScores);
+        reward(addresses, scores);
+        round.totalScores += sumOfScores;
 
-        if (allScoresSubmitted(round.scores)) {
-            reward(round.addresses, round.scores);
-            cleanUpRound(round, roundIndex);
+        if (round.totalScores == MAX_SCORE) {
+            deleteRound(roundIndex);
         }
     }
 
-    function cleanUpRound(Round storage round, uint roundIndex) private {
-        round.end = 0;
-        delete round.addresses;
-        delete round.scores;
-        round.exists = false;
+    function deleteRound(uint roundIndex) private {
         delete openRounds[roundIndex];
+
+        // Find index inside `openRoundIndexes` and remove it while shrinking
+        // the array.
+        uint openRoundIndexesIndex;
+        for (uint i = 0; i < openRoundIndexes.length; i++) {
+            if (openRoundIndexes[i] == roundIndex) {
+                openRoundIndexesIndex = i;
+                break;
+            }
+        }
+        for (
+            uint i = openRoundIndexesIndex;
+            i < openRoundIndexes.length - 1;
+            i++
+        ) {
+            openRoundIndexes[i] = openRoundIndexes[i + 1];
+        }
+        openRoundIndexes.pop();
     }
 
-    function allScoresSubmitted(
-        uint64[] memory scores
-    ) private pure returns (bool) {
-        uint totalScore = 0;
+    function adminDeleteRound(uint roundIndex) public onlyAdmin {
+        require(roundIndex < currentRoundIndex, "Round not finished");
+        deleteRound(roundIndex);
+    }
+
+    function validateScores(
+        uint64[] memory scores,
+        uint scoresAlreadySubmitted
+    ) private pure returns (uint) {
+        uint64 sum = 0;
         for (uint i = 0; i < scores.length; i++) {
-            totalScore += scores[i];
+            sum += scores[i];
         }
-        return totalScore >= MAX_SCORE;
+        require(sum <= MAX_SCORE, "Sum of scores too big");
+        require(
+            sum + scoresAlreadySubmitted <= MAX_SCORE,
+            "Sum of scores including historic too big"
+        );
+        return sum;
     }
 
     function reward(
         address payable[] memory addresses,
         uint64[] memory scores
     ) private {
-        validateScores(scores);
-        require(address(this).balance >= roundReward, "Not enough funds");
+        uint totalAmount = 0;
+        uint[] memory amounts = new uint[](addresses.length);
+
         for (uint i = 0; i < addresses.length; i++) {
-            address payable addr = addresses[i];
             uint score = scores[i];
             uint256 amount = (score * roundReward) / MAX_SCORE;
+            amounts[i] = amount;
+            totalAmount += amount;
+        }
+
+        require(address(this).balance >= totalAmount, "Not enough funds");
+
+        for (uint i = 0; i < addresses.length; i++) {
+            address payable addr = addresses[i];
+            uint256 amount = amounts[i];
             if (addr.send(amount)) {
                 emit Transfer(addr, amount);
             } else {
@@ -135,12 +168,8 @@ contract ImpactEvaluator is AccessControl {
         }
     }
 
-    function validateScores(uint64[] memory scores) private pure {
-        uint64 sum = 0;
-        for (uint i = 0; i < scores.length; i++) {
-            sum += scores[i];
-        }
-        require(sum <= MAX_SCORE, "Sum of scores too big");
+    function getOpenRoundIndexes() public view returns (uint[] memory) {
+        return openRoundIndexes;
     }
 
     modifier onlyAdmin() {

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -16,7 +16,7 @@ contract ImpactEvaluatorTest is Test {
     function test_AdvanceRound() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
         assertEq(impactEvaluator.currentRoundIndex(), 0);
-        (uint end, , ) = impactEvaluator.openRounds(0);
+        (, uint end, ) = impactEvaluator.openRounds(0);
         assertEq(end, block.number + 10);
         vm.expectEmit(false, false, false, true);
         emit RoundStart(1);
@@ -26,13 +26,13 @@ contract ImpactEvaluatorTest is Test {
 
     function test_SetNextRoundLength() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
-        (uint end, , ) = impactEvaluator.openRounds(0);
+        (, uint end,) = impactEvaluator.openRounds(0);
         assertEq(end, block.number + 10);
         impactEvaluator.setNextRoundLength(20);
-        (end, , ) = impactEvaluator.openRounds(0);
+        (, end, ) = impactEvaluator.openRounds(0);
         assertEq(end, block.number + 10);
         impactEvaluator.adminAdvanceRound();
-        (end, , ) = impactEvaluator.openRounds(1);
+        (, end, ) = impactEvaluator.openRounds(1);
         assertEq(end, block.number + 20);
         vm.expectRevert("Next round length must be positive");
         impactEvaluator.setNextRoundLength(0);
@@ -212,46 +212,16 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.setScores(0, addresses, scores);
     }
 
-    function test_OpenRoundIndexes() public {
-        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
-        vm.deal(payable(address(impactEvaluator)), 100 ether);
-        
-        uint[] memory openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
-        assertEq(openRoundIndexes.length, 1, "one open round index");
-        assertEq(openRoundIndexes[0], 0, "round 0");
-
-        impactEvaluator.adminAdvanceRound();
-        openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
-        assertEq(openRoundIndexes.length, 2, "two open round index");
-        assertEq(openRoundIndexes[1], 1, "round 1");
-
-        address payable[] memory addresses = new address payable[](1);
-        uint64[] memory scores = new uint64[](1);
-        addresses[0] = payable(vm.addr(1));
-        scores[0] = impactEvaluator.MAX_SCORE();
-        impactEvaluator.setScores(0, addresses, scores);
-
-        openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
-        assertEq(openRoundIndexes.length, 1, "one open round index");
-        assertEq(openRoundIndexes[0], 1, "round 1");
-
-        impactEvaluator.adminAdvanceRound();
-        impactEvaluator.adminDeleteRound(1);
-        openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
-        assertEq(openRoundIndexes.length, 1, "one open round index");
-        assertEq(openRoundIndexes[0], 2, "round 2");
-    }
-
-    function test_AdminDeleteRound() public {
+    function test_AdminDeleteOpenRound() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(vm.addr(1)));
         vm.expectRevert("Not an admin");
-        impactEvaluator.adminDeleteRound(0);
+        impactEvaluator.adminDeleteOpenRound(0);
 
         impactEvaluator = new ImpactEvaluator(address(this));
         vm.expectRevert("Round not finished");
-        impactEvaluator.adminDeleteRound(0);
+        impactEvaluator.adminDeleteOpenRound(0);
 
         impactEvaluator.adminAdvanceRound();
-        impactEvaluator.adminDeleteRound(0);
+        impactEvaluator.adminDeleteOpenRound(0);
     }
 }

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -16,7 +16,7 @@ contract ImpactEvaluatorTest is Test {
     function test_AdvanceRound() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
         assertEq(impactEvaluator.currentRoundIndex(), 0);
-        (uint end, ) = impactEvaluator.openRounds(0);
+        (uint end, , ) = impactEvaluator.openRounds(0);
         assertEq(end, block.number + 10);
         vm.expectEmit(false, false, false, true);
         emit RoundStart(1);
@@ -26,13 +26,13 @@ contract ImpactEvaluatorTest is Test {
 
     function test_SetNextRoundLength() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
-        (uint end, ) = impactEvaluator.openRounds(0);
+        (uint end, , ) = impactEvaluator.openRounds(0);
         assertEq(end, block.number + 10);
         impactEvaluator.setNextRoundLength(20);
-        (end, ) = impactEvaluator.openRounds(0);
+        (end, , ) = impactEvaluator.openRounds(0);
         assertEq(end, block.number + 10);
         impactEvaluator.adminAdvanceRound();
-        (end, ) = impactEvaluator.openRounds(1);
+        (end, , ) = impactEvaluator.openRounds(1);
         assertEq(end, block.number + 20);
         vm.expectRevert("Next round length must be positive");
         impactEvaluator.setNextRoundLength(0);
@@ -173,11 +173,85 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.setScores(0, addresses, scores);
     }
 
+    function test_SetScoresTooBigHistoric() public {
+        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        impactEvaluator.adminAdvanceRound();
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
+
+        address payable[] memory addresses = new address payable[](1);
+        addresses[0] = payable(vm.addr(1));
+        uint64[] memory scores = new uint64[](1);
+        scores[0] = impactEvaluator.MAX_SCORE() - 1;
+        impactEvaluator.setScores(0, addresses, scores);
+    
+        scores[0] = 2;
+        vm.expectRevert("Sum of scores including historic too big");
+        impactEvaluator.setScores(0, addresses, scores);
+    }
+
+    function test_SetScoresOverflow() public {
+        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        impactEvaluator.adminAdvanceRound();
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
+
+        address payable[] memory addresses = new address payable[](2);
+        uint64[] memory scores = new uint64[](2);
+        addresses[0] = payable(vm.addr(1));
+        addresses[1] = payable(vm.addr(1));
+        scores[0] = 2**64 - 1;
+        scores[1] = 1;
+        vm.expectRevert();
+        impactEvaluator.setScores(0, addresses, scores);
+    }
+
     function test_SetScoresUnfinishedRound() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
         address payable[] memory addresses = new address payable[](0);
         uint64[] memory scores = new uint64[](0);
         vm.expectRevert("Round not finished");
         impactEvaluator.setScores(0, addresses, scores);
+    }
+
+    function test_OpenRoundIndexes() public {
+        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
+        
+        uint[] memory openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
+        assertEq(openRoundIndexes.length, 1, "one open round index");
+        assertEq(openRoundIndexes[0], 0, "round 0");
+
+        impactEvaluator.adminAdvanceRound();
+        openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
+        assertEq(openRoundIndexes.length, 2, "two open round index");
+        assertEq(openRoundIndexes[1], 1, "round 1");
+
+        address payable[] memory addresses = new address payable[](1);
+        uint64[] memory scores = new uint64[](1);
+        addresses[0] = payable(vm.addr(1));
+        scores[0] = impactEvaluator.MAX_SCORE();
+        impactEvaluator.setScores(0, addresses, scores);
+
+        openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
+        assertEq(openRoundIndexes.length, 1, "one open round index");
+        assertEq(openRoundIndexes[0], 1, "round 1");
+
+        impactEvaluator.adminAdvanceRound();
+        impactEvaluator.adminDeleteRound(1);
+        openRoundIndexes = impactEvaluator.getOpenRoundIndexes();
+        assertEq(openRoundIndexes.length, 1, "one open round index");
+        assertEq(openRoundIndexes[0], 2, "round 2");
+    }
+
+    function test_AdminDeleteRound() public {
+        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(vm.addr(1)));
+        vm.expectRevert("Not an admin");
+        impactEvaluator.adminDeleteRound(0);
+
+        impactEvaluator = new ImpactEvaluator(address(this));
+        vm.expectRevert("Round not finished");
+        impactEvaluator.adminDeleteRound(0);
+
+        impactEvaluator.adminAdvanceRound();
+        impactEvaluator.adminDeleteRound(0);
     }
 }


### PR DESCRIPTION
Sorry for yet another refactor PR, but this one makes the code safer and cheaper by storing open rounds in an array instead of maintaining a mapping and an array of indexes (which have to stay in sync).