### PR TITLE
Reward only available balance

### DIFF
--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -145,9 +145,13 @@ contract ImpactEvaluator is AccessControl, Nonces {
         uint64[] memory scores
     ) private {
         for (uint i = 0; i < addresses.length; i++) {
-            balances[addresses[i]] +=
-                (scores[i] * round.roundReward) /
-                MAX_SCORE;
+            address payable participant = addresses[i];
+            uint amount = (scores[i] * round.roundReward) / MAX_SCORE;
+            if (participant == 0x000000000000000000000000000000000000dEaD) {
+                balanceHeld -= amount;
+            } else {
+                balances[participant] += amount;
+            }
         }
     }
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -135,8 +135,13 @@ contract ImpactEvaluator is AccessControl, Nonces {
         address payable[] memory addresses,
         uint64[] memory scores
     ) private {
+        uint availableRoundReward = address(this).balance < roundReward
+            ? address(this).balance
+            : roundReward;
         for (uint i = 0; i < addresses.length; i++) {
-            balances[addresses[i]] += (scores[i] * roundReward) / MAX_SCORE;
+            balances[addresses[i]] +=
+                (scores[i] * availableRoundReward) /
+                MAX_SCORE;
         }
     }
 

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -63,6 +63,7 @@ contract ImpactEvaluatorTest is Test {
 
     function test_SetScores() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
         impactEvaluator.adminAdvanceRound();
         impactEvaluator.revokeRole(
             impactEvaluator.DEFAULT_ADMIN_ROLE(),
@@ -88,6 +89,7 @@ contract ImpactEvaluatorTest is Test {
 
     function test_SetScoresMultipleParticipants() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
         impactEvaluator.adminAdvanceRound();
 
         address payable[] memory addresses = new address payable[](3);
@@ -111,6 +113,7 @@ contract ImpactEvaluatorTest is Test {
 
     function test_SetScoresFractions() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
         impactEvaluator.adminAdvanceRound();
 
         address payable[] memory addresses = new address payable[](2);
@@ -143,6 +146,7 @@ contract ImpactEvaluatorTest is Test {
 
     function test_SetScoresMultipleCalls() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
         impactEvaluator.adminAdvanceRound();
         uint64 iterations = 10;
         for (uint i = 0; i < iterations; i++) {
@@ -242,6 +246,7 @@ contract ImpactEvaluatorTest is Test {
     function test_BalanceOf() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
         assertEq(impactEvaluator.balanceOf(address(this)), 0);
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
 
         impactEvaluator.adminAdvanceRound();
         address payable[] memory addresses = new address payable[](1);

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -527,4 +527,34 @@ contract ImpactEvaluatorTest is Test {
             "no extra reward"
         );
     }
+
+    function test_RewardBurner() public {
+        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        // round 0: 0 ether available
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
+        impactEvaluator.adminAdvanceRound();
+        // round 1: 100 ether available
+        impactEvaluator.adminAdvanceRound();
+        // round 2: 0 ether available
+
+        address payable[] memory addresses = new address payable[](1);
+        addresses[0] = payable(0x000000000000000000000000000000000000dEaD);
+        uint64[] memory scores = new uint64[](1);
+        scores[0] = impactEvaluator.MAX_SCORE();
+
+        impactEvaluator.setScores(1, addresses, scores);
+
+        impactEvaluator.adminAdvanceRound();
+        // round 3: 100 ether available
+        impactEvaluator.adminAdvanceRound();
+        // round 4: 0 ether available
+
+        addresses[0] = payable(address(this));
+        impactEvaluator.setScores(3, addresses, scores);
+        assertEq(
+            impactEvaluator.balanceOf(address(this)),
+            100 ether,
+            "burner reward was added back to the pool"
+        );
+    }
 }


### PR DESCRIPTION
At round start, store the available round reward in the round struct. Usually it's the desired configured `roundReward`, however if the contract's balance is less than that, it falls back to that.

This has the funny side effect that the first round is a free run. I don't see an issue with that. The alternative would be setting the available round reward when the first `setScores` call happens, which is unfortunately more complex and more costly.

- [x] Reward only available balance
- [x] Add special case for burner address