### PR TITLE
Optimize `setScores()` gas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out
 
 ## Rust Target Files
 **/**/target
+.gas-snapshot

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 solc-version = "0.8.21"
 optimizer = true
 optimizer-runs = 10_000_000
+gas_reports = ["ImpactEvaluator", "Balances"]
 
 [rpc_endpoints]
 calibration = "https://api.calibration.node.glif.io/rpc/v1"

--- a/src/Balances.sol
+++ b/src/Balances.sol
@@ -36,9 +36,16 @@ contract Balances {
         uint amount
     ) internal {
         uint oldBalance = balances[participant];
-        uint newBalance = oldBalance + amount;
+        uint newBalance;
+        // The monthly balance will never exceed 2^256-1 wei 
+        unchecked {
+            newBalance = oldBalance + amount;
+        }
         balances[participant] = newBalance;
-        balanceHeld += amount;
+        // The monthly total holding will never exceed 2^256-1 wei 
+        unchecked {
+            balanceHeld += amount;
+        }
         if (
             oldBalance <= minBalanceForTransfer &&
             newBalance > minBalanceForTransfer

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -103,7 +103,10 @@ contract ImpactEvaluator is AccessControl, Balances {
 
         uint sumOfScores = validateScores(scores);
         reward(addresses, scores);
-        previousRoundTotalScores += sumOfScores;
+        // Scores have passed `validateScores()`
+        unchecked {
+            previousRoundTotalScores += sumOfScores;
+        }
     }
 
     function validateScores(uint64[] memory scores) public view returns (uint) {
@@ -125,11 +128,18 @@ contract ImpactEvaluator is AccessControl, Balances {
     ) private {
         for (uint i = 0; i < addresses.length; i++) {
             address payable participant = addresses[i];
-            uint amount = (scores[i] * previousRoundRoundReward) / MAX_SCORE;
+            uint amount;
+            // Scores have passed `validateScores()`
+            unchecked {
+                amount = (scores[i] * previousRoundRoundReward) / MAX_SCORE;
+            }
             if (participant != 0x000000000000000000000000000000000000dEaD) {
                 increaseParticipantBalance(participant, amount);
             }
-            previousRoundRemainingReward -= amount;
+            // Scores have passed `validateScores()`
+            unchecked {
+                previousRoundRemainingReward -= amount;
+            }
         }
     }
 


### PR DESCRIPTION
This bring down gas 1-2%, using unchecked arithmetic.

I'm not sure this is the way to go, as it clutters the code, and we might expect more savings from conceptual refactors instead.