### PR TITLE
Update scores from `uint64` to `uint`

### DIFF
--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -17,7 +17,7 @@ contract ImpactEvaluator is AccessControl, Balances {
     uint public nextRoundLength = 10;
     uint public roundReward = 100 ether;
 
-    uint64 public constant MAX_SCORE = 1e15;
+    uint public constant MAX_SCORE = 1e15;
 
     event MeasurementsAdded(
         string cid,
@@ -89,7 +89,7 @@ contract ImpactEvaluator is AccessControl, Balances {
     function setScores(
         uint roundIndex,
         address payable[] memory addresses,
-        uint64[] memory scores
+        uint[] memory scores
     ) public onlyEvaluator {
         require(
             addresses.length == scores.length,
@@ -106,8 +106,8 @@ contract ImpactEvaluator is AccessControl, Balances {
         previousRoundTotalScores += sumOfScores;
     }
 
-    function validateScores(uint64[] memory scores) public view returns (uint) {
-        uint64 sum = 0;
+    function validateScores(uint[] memory scores) public view returns (uint) {
+        uint sum = 0;
         for (uint i = 0; i < scores.length; i++) {
             sum += scores[i];
         }
@@ -121,7 +121,7 @@ contract ImpactEvaluator is AccessControl, Balances {
 
     function reward(
         address payable[] memory addresses,
-        uint64[] memory scores
+        uint[] memory scores
     ) private {
         for (uint i = 0; i < addresses.length; i++) {
             address payable participant = addresses[i];

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -70,7 +70,7 @@ contract ImpactEvaluatorTest is Test {
     function test_SetScoresNotEvaluator() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(0x1));
         vm.expectRevert("Not an evaluator");
-        impactEvaluator.setScores(0, new address payable[](0), new uint64[](0));
+        impactEvaluator.setScores(0, new address payable[](0), new uint[](0));
     }
 
     function test_SetScores() public {
@@ -83,11 +83,11 @@ contract ImpactEvaluatorTest is Test {
             address(this)
         );
         vm.expectRevert("Addresses and scores length mismatch");
-        impactEvaluator.setScores(1, new address payable[](1), new uint64[](0));
+        impactEvaluator.setScores(1, new address payable[](1), new uint[](0));
 
         address payable[] memory addresses = new address payable[](1);
         addresses[0] = payable(vm.addr(1));
-        uint64[] memory scores = new uint64[](1);
+        uint[] memory scores = new uint[](1);
         scores[0] = impactEvaluator.MAX_SCORE();
         impactEvaluator.setScores(1, addresses, scores);
         assertEq(
@@ -114,7 +114,7 @@ contract ImpactEvaluatorTest is Test {
         addresses[1] = payable(vm.addr(2));
         addresses[2] = payable(vm.addr(3));
 
-        uint64[] memory scores = new uint64[](3);
+        uint[] memory scores = new uint[](3);
         scores[0] = 50e13;
         scores[1] = 25e13;
         scores[2] = 25e13;
@@ -137,7 +137,7 @@ contract ImpactEvaluatorTest is Test {
         address payable[] memory addresses = new address payable[](2);
         addresses[0] = payable(vm.addr(1));
         addresses[1] = payable(vm.addr(2));
-        uint64[] memory scores = new uint64[](2);
+        uint[] memory scores = new uint[](2);
         scores[0] = impactEvaluator.MAX_SCORE() - 1;
         scores[1] = 1;
         impactEvaluator.setScores(1, addresses, scores);
@@ -158,7 +158,7 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.adminAdvanceRound();
 
         address payable[] memory addresses = new address payable[](0);
-        uint64[] memory scores = new uint64[](0);
+        uint[] memory scores = new uint[](0);
         impactEvaluator.setScores(0, addresses, scores);
     }
 
@@ -167,11 +167,11 @@ contract ImpactEvaluatorTest is Test {
         vm.deal(payable(address(impactEvaluator)), 100 ether);
         impactEvaluator.adminAdvanceRound();
         impactEvaluator.adminAdvanceRound();
-        uint64 iterations = 10;
+        uint iterations = 10;
         for (uint i = 0; i < iterations; i++) {
             address payable[] memory addresses = new address payable[](1);
             addresses[0] = payable(vm.addr(i + 1));
-            uint64[] memory scores = new uint64[](1);
+            uint[] memory scores = new uint[](1);
             scores[0] = impactEvaluator.MAX_SCORE() / iterations;
             impactEvaluator.setScores(1, addresses, scores);
         }
@@ -190,7 +190,7 @@ contract ImpactEvaluatorTest is Test {
 
         address payable[] memory addresses = new address payable[](1);
         addresses[0] = payable(vm.addr(1));
-        uint64[] memory scores = new uint64[](1);
+        uint[] memory scores = new uint[](1);
         scores[0] = impactEvaluator.MAX_SCORE() + 1;
         vm.expectRevert("Sum of scores too big");
         impactEvaluator.setScores(0, addresses, scores);
@@ -202,7 +202,7 @@ contract ImpactEvaluatorTest is Test {
 
         address payable[] memory addresses = new address payable[](1);
         addresses[0] = payable(vm.addr(1));
-        uint64[] memory scores = new uint64[](1);
+        uint[] memory scores = new uint[](1);
         scores[0] = impactEvaluator.MAX_SCORE() - 1;
         impactEvaluator.setScores(0, addresses, scores);
 
@@ -216,7 +216,7 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.adminAdvanceRound();
 
         address payable[] memory addresses = new address payable[](2);
-        uint64[] memory scores = new uint64[](2);
+        uint[] memory scores = new uint[](2);
         addresses[0] = payable(vm.addr(1));
         addresses[1] = payable(vm.addr(1));
         scores[0] = 2 ** 64 - 1;
@@ -228,7 +228,7 @@ contract ImpactEvaluatorTest is Test {
     function test_SetScoresUnfinishedRound() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
         address payable[] memory addresses = new address payable[](0);
-        uint64[] memory scores = new uint64[](0);
+        uint[] memory scores = new uint[](0);
         vm.expectRevert("Can only score previous round");
         impactEvaluator.setScores(0, addresses, scores);
     }
@@ -239,7 +239,7 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.adminAdvanceRound();
 
         address payable[] memory addresses = new address payable[](1);
-        uint64[] memory scores = new uint64[](1);
+        uint[] memory scores = new uint[](1);
         addresses[0] = payable(vm.addr(1));
         scores[0] = impactEvaluator.MAX_SCORE();
         impactEvaluator.setScores(0, addresses, scores);
@@ -261,7 +261,7 @@ contract ImpactEvaluatorTest is Test {
 
         address payable[] memory addresses = new address payable[](1);
         addresses[0] = payable(address(this));
-        uint64[] memory scores = new uint64[](1);
+        uint[] memory scores = new uint[](1);
         scores[0] = impactEvaluator.MAX_SCORE();
         impactEvaluator.setScores(1, addresses, scores);
 
@@ -280,7 +280,7 @@ contract ImpactEvaluatorTest is Test {
 
         address payable[] memory addresses = new address payable[](1);
         addresses[0] = payable(vm.addr(1));
-        uint64[] memory scores = new uint64[](1);
+        uint[] memory scores = new uint[](1);
         scores[0] = impactEvaluator.MAX_SCORE();
 
         impactEvaluator.setScores(1, addresses, scores);
@@ -318,7 +318,7 @@ contract ImpactEvaluatorTest is Test {
 
         address payable[] memory addresses = new address payable[](1);
         addresses[0] = payable(0x000000000000000000000000000000000000dEaD);
-        uint64[] memory scores = new uint64[](1);
+        uint[] memory scores = new uint[](1);
         scores[0] = impactEvaluator.MAX_SCORE();
 
         impactEvaluator.setScores(1, addresses, scores);
@@ -349,7 +349,7 @@ contract ImpactEvaluatorTest is Test {
 
         address payable[] memory addresses = new address payable[](1);
         addresses[0] = payable(vm.addr(1));
-        uint64[] memory scores = new uint64[](1);
+        uint[] memory scores = new uint[](1);
         scores[0] = impactEvaluator.MAX_SCORE();
         impactEvaluator.setScores(1, addresses, scores);
         assertEq(vm.addr(1).balance, 0);
@@ -372,11 +372,11 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.adminAdvanceRound();
         impactEvaluator.adminAdvanceRound();
 
-        uint64 participants = 10;
+        uint participants = 10;
         address payable[] memory addresses = new address payable[](
             participants
         );
-        uint64[] memory scores = new uint64[](participants);
+        uint[] memory scores = new uint[](participants);
         for (uint i = 0; i < participants; i++) {
             addresses[i] = payable(vm.addr(i + 1));
             scores[i] = impactEvaluator.MAX_SCORE() / participants;
@@ -467,7 +467,7 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.adminAdvanceRound();
         address payable[] memory addresses = new address payable[](1);
         addresses[0] = payable(vm.addr(1));
-        uint64[] memory scores = new uint64[](1);
+        uint[] memory scores = new uint[](1);
         scores[0] = impactEvaluator.MAX_SCORE();
         impactEvaluator.setScores(1, addresses, scores);
         assertEq(impactEvaluator.availableBalance(), 100 ether);
@@ -491,7 +491,7 @@ contract ImpactEvaluatorTest is Test {
 
         address payable[] memory addresses = new address payable[](1);
         addresses[0] = payable(vm.addr(1));
-        uint64[] memory scores = new uint64[](1);
+        uint[] memory scores = new uint[](1);
         scores[0] = impactEvaluator.MAX_SCORE();
         impactEvaluator.setScores(1, addresses, scores);
 
@@ -513,7 +513,7 @@ contract ImpactEvaluatorTest is Test {
 
         address payable[] memory addresses = new address payable[](1);
         addresses[0] = payable(vm.addr(1));
-        uint64[] memory scores = new uint64[](1);
+        uint[] memory scores = new uint[](1);
         scores[0] = 1;
 
         for (uint i = 0; i < 1000; i++) {


### PR DESCRIPTION
uint256 is cheaper than uint64, this reduces cost by ~1.5%

See also https://www.linkedin.com/pulse/solidity-gas-golfing-1-uint8-vs-uint256-sudeep-sagar/

cc @AmeanAsad 

```
test_TransferScheduled() (gas: -25169 (-0.997%)) 
test_SetScoresMultipleCalls() (gas: -31425 (-1.293%)) 
test_SetScoresMultipleParticipants() (gas: -29157 (-1.432%)) 
test_SetScoresFractions() (gas: -29135 (-1.482%)) 
test_RewardBurner() (gas: -29136 (-1.492%)) 
test_rewardsScheduledFor() (gas: -29030 (-1.496%)) 
test_MinBalanceForTransfer() (gas: -29115 (-1.502%)) 
test_SetScores() (gas: -29129 (-1.504%)) 
test_Reward() (gas: -29242 (-1.506%)) 
test_AvailableBalance() (gas: -29219 (-1.524%)) 
test_ReleaseReward() (gas: -28898 (-1.525%)) 
test_AdvanceRoundCleanUp() (gas: -29030 (-1.598%)) 
test_SetScoresTooBigHistoric() (gas: -29153 (-1.606%)) 
test_SetScoresOverflow() (gas: -28792 (-1.611%)) 
test_AdvanceRound() (gas: -28775 (-1.612%)) 
test_SetNextRoundLength() (gas: -28819 (-1.613%)) 
test_SetScoresEmptyRound() (gas: -28902 (-1.622%)) 
test_SetScoresTooBig() (gas: -29023 (-1.624%)) 
test_AddMeasurements() (gas: -28863 (-1.634%)) 
test_SetScoresNotEvaluator() (gas: -28884 (-1.639%)) 
test_SetRoundRewardNotAdmin() (gas: -28886 (-1.640%)) 
test_SetScoresUnfinishedRound() (gas: -28884 (-1.641%)) 
test_SetRoundReward() (gas: -28842 (-1.641%)) 
test_GasSetScores() (gas: -134881 (-1.755%)) 
Overall gas change: -800389 (-1.553%)
```