### PR TITLE
Inline `reward` and `validateScores` for gas

### DIFF
--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -114,7 +114,6 @@ contract ImpactEvaluator is AccessControl, Balances {
             }
             previousRoundRemainingReward -= amount;
         }
-        require(sumOfScores <= MAX_SCORE, "Sum of scores too big");
         require(
             sumOfScores + previousRoundTotalScores <= MAX_SCORE,
             "Sum of scores including historic too big"

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -103,9 +103,10 @@ contract ImpactEvaluator is AccessControl, Balances {
         
         uint64 sumOfScores = 0;
         for (uint i = 0; i < addresses.length; i++) {
-            sumOfScores += scores[i];
+            uint64 score = scores[i];
             address payable participant = addresses[i];
-            uint amount = (scores[i] * previousRoundRoundReward) / MAX_SCORE;
+            sumOfScores += score;
+            uint amount = (score * previousRoundRoundReward) / MAX_SCORE;
             if (participant != 0x000000000000000000000000000000000000dEaD) {
                 increaseParticipantBalance(participant, amount);
             }

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -100,30 +100,10 @@ contract ImpactEvaluator is AccessControl, Balances {
                 roundIndex == previousRoundIndex,
             "Can only score previous round"
         );
-
-        uint sumOfScores = validateScores(scores);
-        reward(addresses, scores);
-        previousRoundTotalScores += sumOfScores;
-    }
-
-    function validateScores(uint64[] memory scores) public view returns (uint) {
-        uint64 sum = 0;
-        for (uint i = 0; i < scores.length; i++) {
-            sum += scores[i];
-        }
-        require(sum <= MAX_SCORE, "Sum of scores too big");
-        require(
-            sum + previousRoundTotalScores <= MAX_SCORE,
-            "Sum of scores including historic too big"
-        );
-        return sum;
-    }
-
-    function reward(
-        address payable[] memory addresses,
-        uint64[] memory scores
-    ) private {
+        
+        uint64 sumOfScores = 0;
         for (uint i = 0; i < addresses.length; i++) {
+            sumOfScores += scores[i];
             address payable participant = addresses[i];
             uint amount = (scores[i] * previousRoundRoundReward) / MAX_SCORE;
             if (participant != 0x000000000000000000000000000000000000dEaD) {
@@ -131,6 +111,12 @@ contract ImpactEvaluator is AccessControl, Balances {
             }
             previousRoundRemainingReward -= amount;
         }
+        require(sumOfScores <= MAX_SCORE, "Sum of scores too big");
+        require(
+            sumOfScores + previousRoundTotalScores <= MAX_SCORE,
+            "Sum of scores including historic too big"
+        );
+        previousRoundTotalScores += sumOfScores;
     }
 
     function releaseRewards() public onlyAdmin {

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -96,7 +96,7 @@ contract ImpactEvaluatorTest is Test {
             "correct balance"
         );
 
-        vm.expectRevert("Sum of scores including historic too big");
+        vm.expectRevert();
         impactEvaluator.setScores(1, addresses, scores);
 
         vm.expectRevert("Can only score previous round");

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -96,9 +96,6 @@ contract ImpactEvaluatorTest is Test {
             "correct balance"
         );
 
-        vm.expectRevert();
-        impactEvaluator.setScores(1, addresses, scores);
-
         vm.expectRevert("Can only score previous round");
         impactEvaluator.setScores(0, addresses, scores);
     }

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -192,7 +192,7 @@ contract ImpactEvaluatorTest is Test {
         addresses[0] = payable(vm.addr(1));
         uint[] memory scores = new uint[](1);
         scores[0] = impactEvaluator.MAX_SCORE() + 1;
-        vm.expectRevert("Sum of scores too big");
+        vm.expectRevert("Sum of scores including historic too big");
         impactEvaluator.setScores(0, addresses, scores);
     }
 


### PR DESCRIPTION
Lowers gas by 2-4%

- Removes one redundant loop
- Removes two functions

```
test_TransferScheduled() (gas: -30928 (-1.225%)) 
test_SetScoresMultipleCalls() (gas: -38387 (-1.580%)) 
test_SetScoresMultipleParticipants() (gas: -36536 (-1.794%)) 
test_SetScoresOverflow() (gas: -32317 (-1.809%)) 
test_SetScoresTooBig() (gas: -32317 (-1.809%)) 
test_SetScores() (gas: -35288 (-1.822%)) 
test_SetScoresFractions() (gas: -36422 (-1.852%)) 
test_rewardsScheduledFor() (gas: -36308 (-1.871%)) 
test_RewardBurner() (gas: -36539 (-1.871%)) 
test_MinBalanceForTransfer() (gas: -36539 (-1.885%)) 
test_Reward() (gas: -36770 (-1.893%)) 
test_SetScoresTooBigHistoric() (gas: -34548 (-1.904%)) 
test_AvailableBalance() (gas: -36539 (-1.906%)) 
test_ReleaseReward() (gas: -36308 (-1.916%)) 
test_AdvanceRoundCleanUp() (gas: -36308 (-1.999%)) 
test_SetNextRoundLength() (gas: -36077 (-2.020%)) 
test_AdvanceRound() (gas: -36077 (-2.021%)) 
test_SetScoresEmptyRound() (gas: -36194 (-2.031%)) 
test_AddMeasurements() (gas: -36077 (-2.043%)) 
test_SetScoresNotEvaluator() (gas: -36077 (-2.047%)) 
test_SetRoundRewardNotAdmin() (gas: -36077 (-2.049%)) 
test_SetScoresUnfinishedRound() (gas: -36077 (-2.049%)) 
test_SetRoundReward() (gas: -36077 (-2.053%)) 
test_GasSetScores() (gas: -267077 (-3.475%)) 
Overall gas change: -1087864 (-2.111%)
```