### PR TITLE
batch `setScores` updates

### DIFF
--- a/src/Balances.sol
+++ b/src/Balances.sol
@@ -31,6 +31,9 @@ contract Balances {
         return scheduledForTransfer.length;
     }
 
+    // `increaseParticipantBalance` and `increaseBalanceHeld` need to be called
+    // in tandem.
+
     function increaseParticipantBalance(
         address payable participant,
         uint amount
@@ -38,13 +41,16 @@ contract Balances {
         uint oldBalance = balances[participant];
         uint newBalance = oldBalance + amount;
         balances[participant] = newBalance;
-        balanceHeld += amount;
         if (
             oldBalance <= minBalanceForTransfer &&
             newBalance > minBalanceForTransfer
         ) {
             readyForTransfer.push(participant);
         }
+    }
+
+    function increaseBalanceHeld(uint amount) internal {
+        balanceHeld += amount;
     }
 
     function _releaseRewards() internal {

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -125,9 +125,10 @@ contract ImpactEvaluator is AccessControl, Balances {
     ) private {
         uint addedBalance = 0;
         uint balanceConsumed = 0;
+        uint scoreUnit = previousRoundRoundReward / MAX_SCORE;
         for (uint i = 0; i < addresses.length; i++) {
             address payable participant = addresses[i];
-            uint amount = (scores[i] * previousRoundRoundReward) / MAX_SCORE;
+            uint amount = scores[i] * scoreUnit;
             if (participant != 0x000000000000000000000000000000000000dEaD) {
                 increaseParticipantBalance(participant, amount);
                 addedBalance += amount;

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -123,14 +123,17 @@ contract ImpactEvaluator is AccessControl, Balances {
         address payable[] memory addresses,
         uint64[] memory scores
     ) private {
+        uint addedBalance = 0;
         for (uint i = 0; i < addresses.length; i++) {
             address payable participant = addresses[i];
             uint amount = (scores[i] * previousRoundRoundReward) / MAX_SCORE;
             if (participant != 0x000000000000000000000000000000000000dEaD) {
                 increaseParticipantBalance(participant, amount);
+                addedBalance += amount;
             }
             previousRoundRemainingReward -= amount;
         }
+        increaseBalanceHeld(addedBalance);
     }
 
     function releaseRewards() public onlyAdmin {

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -124,6 +124,7 @@ contract ImpactEvaluator is AccessControl, Balances {
         uint64[] memory scores
     ) private {
         uint addedBalance = 0;
+        uint balanceConsumed = 0;
         for (uint i = 0; i < addresses.length; i++) {
             address payable participant = addresses[i];
             uint amount = (scores[i] * previousRoundRoundReward) / MAX_SCORE;
@@ -131,8 +132,9 @@ contract ImpactEvaluator is AccessControl, Balances {
                 increaseParticipantBalance(participant, amount);
                 addedBalance += amount;
             }
-            previousRoundRemainingReward -= amount;
+            balanceConsumed += amount;
         }
+        previousRoundRemainingReward -= balanceConsumed;
         increaseBalanceHeld(addedBalance);
     }
 

--- a/src/ImpactEvaluator.sol
+++ b/src/ImpactEvaluator.sol
@@ -105,12 +105,11 @@ contract ImpactEvaluator is AccessControl, Balances {
 
         uint sumOfScores = 0;
         uint addedBalance = 0;
-        uint scoreUnit = previousRoundRoundReward / MAX_SCORE;
         for (uint i = 0; i < addresses.length; i++) {
             uint score = scores[i];
             address payable participant = addresses[i];
             sumOfScores += score;
-            uint amount = score * scoreUnit;
+            uint amount = (score * previousRoundRoundReward) / MAX_SCORE;
             if (participant != 0x000000000000000000000000000000000000dEaD) {
                 increaseParticipantBalance(participant, amount);
                 addedBalance += amount;


### PR DESCRIPTION
Instead of updating the storage variables (expensive) for every participant, update once after processing all. Also cache a compution.

While making the whole contract _slightly_ more expensive, this reduces `setScores()` cost for many participants by over 30%.

```
test_TransferScheduled() (gas: 3697 (0.146%)) 
test_SetScoresMultipleParticipants() (gas: 8979 (0.441%)) 
test_SetScoresFractions() (gas: 9601 (0.488%)) 
test_SetScoresMultipleCalls() (gas: 12041 (0.495%)) 
test_rewardsScheduledFor() (gas: 10223 (0.527%)) 
test_SetScores() (gas: 10223 (0.528%)) 
test_MinBalanceForTransfer() (gas: 10425 (0.538%)) 
test_ReleaseReward() (gas: 10223 (0.539%)) 
test_RewardBurner() (gas: 10653 (0.546%)) 
test_Reward() (gas: 10627 (0.547%)) 
test_AvailableBalance() (gas: 10653 (0.556%)) 
test_SetScoresOverflow() (gas: 10021 (0.561%)) 
test_SetScoresTooBig() (gas: 10021 (0.561%)) 
test_SetNextRoundLength() (gas: 10021 (0.561%)) 
test_AdvanceRound() (gas: 10021 (0.561%)) 
test_AdvanceRoundCleanUp() (gas: 10223 (0.563%)) 
test_SetScoresTooBigHistoric() (gas: 10223 (0.563%)) 
test_AddMeasurements() (gas: 10021 (0.567%)) 
test_SetScoresNotEvaluator() (gas: 10021 (0.569%)) 
test_SetRoundRewardNotAdmin() (gas: 10021 (0.569%)) 
test_SetScoresUnfinishedRound() (gas: 10021 (0.569%)) 
test_SetRoundReward() (gas: 10021 (0.570%)) 
test_SetScoresEmptyRound() (gas: 10845 (0.608%)) 
test_GasSetScores() (gas: 212021 (2.759%)) 
test_GasSetScoresManyParticipants() (gas: -62107583 (-23.635%)) 
Overall gas change: -61666737 (-19.620%)
```