### PR TITLE
Add change reward threshold in live contract. Closes #80

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ will be called and the round finishes.
 
 ### `.balanceOf(address account) view -> uint`
 
+### `.participantIsReadyForTransfer(address account) view -> bool`
+
 ## Roles
 
 ### `.EVALUATE_ROLE()`

--- a/src/Balances.sol
+++ b/src/Balances.sol
@@ -26,6 +26,15 @@ contract Balances {
         return scheduledForTransfer.length;
     }
 
+    function participantIsReadyForTransfer (address participant) public view returns (bool) {
+        for (uint i = 0; i < readyForTransfer.length; i++) {
+            if (readyForTransfer[i] == participant) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     function increaseParticipantBalance(
         address payable participant,
         uint amount
@@ -33,9 +42,12 @@ contract Balances {
         uint oldBalance = balances[participant];
         uint newBalance = oldBalance + amount;
         balances[participant] = newBalance;
+        if (newBalance <= minBalanceForTransfer) {
+            return;
+        }
         if (
-            oldBalance <= minBalanceForTransfer &&
-            newBalance > minBalanceForTransfer
+            oldBalance <= minBalanceForTransfer
+            || !participantIsReadyForTransfer(participant)
         ) {
             readyForTransfer.push(participant);
         }

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -237,12 +237,14 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.adminAdvanceRound();
         impactEvaluator.adminAdvanceRound();
 
-        address payable[] memory addresses = new address payable[](2);
+        address payable[] memory addresses = new address payable[](3);
         addresses[0] = payable(vm.addr(1));
         addresses[1] = payable(vm.addr(2));
-        uint[] memory scores = new uint[](2);
+        addresses[2] = payable(vm.addr(3));
+        uint[] memory scores = new uint[](3);
         scores[0] = 1;
         scores[1] = impactEvaluator.MAX_SCORE() - scores[0];
+        scores[2] = 0;
 
         impactEvaluator.setScores(1, addresses, scores);
         assertEq(
@@ -255,18 +257,25 @@ contract ImpactEvaluatorTest is Test {
             true,
             "participant 1 is ready"
         );
+        assertEq(
+            impactEvaluator.participantIsReadyForTransfer(vm.addr(3)),
+            false,
+            "participant 2 is not ready"
+        );
 
-        impactEvaluator.setMinBalanceForTransfer(0);
+        impactEvaluator.setMinBalanceForTransfer(1);
         impactEvaluator.adminAdvanceRound();
 
-        address payable[] memory addresses2 = new address payable[](3);
+        address payable[] memory addresses2 = new address payable[](4);
         addresses2[0] = payable(vm.addr(1));
         addresses2[1] = payable(vm.addr(2));
-        addresses2[2] = payable(0x000000000000000000000000000000000000dEaD);
-        uint[] memory scores2 = new uint[](3);
+        addresses2[2] = payable(vm.addr(3));
+        addresses2[3] = payable(0x000000000000000000000000000000000000dEaD);
+        uint[] memory scores2 = new uint[](4);
         scores2[0] = 0;
         scores2[1] = 0;
-        scores2[2] = impactEvaluator.MAX_SCORE();
+        scores2[2] = 0;
+        scores2[3] = impactEvaluator.MAX_SCORE();
         impactEvaluator.setScores(2, addresses2, scores2);
         assertEq(
             impactEvaluator.participantIsReadyForTransfer(vm.addr(1)),
@@ -277,6 +286,11 @@ contract ImpactEvaluatorTest is Test {
             impactEvaluator.participantIsReadyForTransfer(vm.addr(2)),
             true,
             "participant 1 is still ready"
+        );
+        assertEq(
+            impactEvaluator.participantIsReadyForTransfer(vm.addr(3)),
+            false,
+            "participant 2 is still not ready"
         );
         assertEq(impactEvaluator.readyForTransfer(0), vm.addr(2));
         assertEq(impactEvaluator.readyForTransfer(1), vm.addr(1));

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -830,11 +830,11 @@ contract ImpactEvaluatorTest is Test {
         addresses[1] = payable(vm.addr(2));
         uint[] memory balances = new uint[](2);
         balances[0] = 50 ether;
-        balances[1] = 50 ether;
-        impactEvaluator.addBalances{value: 100 ether}(addresses, balances);
+        balances[1] = impactEvaluator.minBalanceForTransfer() / 2;
+        impactEvaluator.addBalances{value: balances[0] + balances[1]}(addresses, balances);
 
-        assert(impactEvaluator.participantIsReadyForTransfer(addresses[0]));
-        assert(impactEvaluator.participantIsReadyForTransfer(addresses[1]));
+        assert(impactEvaluator.participantIsReadyForTransfer(vm.addr(1)));
+        assert(!impactEvaluator.participantIsReadyForTransfer(vm.addr(2)));
         assert(
             !impactEvaluator.participantIsReadyForTransfer(payable(vm.addr(3)))
         );

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -230,7 +230,7 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.setScores(0, addresses, scores);
     }
 
-    function test_SetScoresAfterUpdateMinBalanceForTransfer() public {
+    function test_SetScoresAfterDecreaseMinBalanceForTransfer() public {
         ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
         vm.deal(payable(address(impactEvaluator)), 100 ether);
 
@@ -251,6 +251,29 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.adminAdvanceRound();
 
         impactEvaluator.setScores(2, addresses, scores);
+        assert(impactEvaluator.participantIsReadyForTransfer(addresses[0]));
+    }
+
+    function test_SetScoresAfterIncreaseMinBalanceForTransfer() public {
+        ImpactEvaluator impactEvaluator = new ImpactEvaluator(address(this));
+        vm.deal(payable(address(impactEvaluator)), 100 ether);
+
+        impactEvaluator.adminAdvanceRound();
+        impactEvaluator.adminAdvanceRound();
+
+        address payable[] memory addresses = new address payable[](1);
+        addresses[0] = payable(vm.addr(1));
+        uint[] memory scores = new uint[](1);
+        scores[0] = impactEvaluator.MAX_SCORE();
+
+        impactEvaluator.setScores(1, addresses, scores);
+        assert(impactEvaluator.participantIsReadyForTransfer(addresses[0]));
+
+        impactEvaluator.setMinBalanceForTransfer(200 ether);
+        impactEvaluator.adminAdvanceRound();
+
+        impactEvaluator.setScores(2, addresses, scores);
+        // Still ready for transfer, although now below the rewards threshold
         assert(impactEvaluator.participantIsReadyForTransfer(addresses[0]));
     }
 

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -239,21 +239,45 @@ contract ImpactEvaluatorTest is Test {
 
         address payable[] memory addresses = new address payable[](2);
         addresses[0] = payable(vm.addr(1));
-        addresses[1] = payable(0x000000000000000000000000000000000000dEaD);
+        addresses[1] = payable(vm.addr(2));
         uint[] memory scores = new uint[](2);
         scores[0] = 1;
         scores[1] = impactEvaluator.MAX_SCORE() - scores[0];
 
         impactEvaluator.setScores(1, addresses, scores);
-        assert(!impactEvaluator.participantIsReadyForTransfer(addresses[0]));
+        assertEq(
+            impactEvaluator.participantIsReadyForTransfer(addresses[0]),
+            false,
+            "participant 0 is not ready"
+        );
+        assertEq(
+            impactEvaluator.participantIsReadyForTransfer(addresses[1]),
+            true,
+            "participant 1 is ready"
+        );
 
         impactEvaluator.setMinBalanceForTransfer(0);
         impactEvaluator.adminAdvanceRound();
 
-        scores[0] = 0;
-        scores[1] = impactEvaluator.MAX_SCORE();
-        impactEvaluator.setScores(2, addresses, scores);
-        assert(impactEvaluator.participantIsReadyForTransfer(addresses[0]));
+        address payable[] memory addresses2 = new address payable[](3);
+        addresses2[0] = payable(vm.addr(1));
+        addresses2[1] = payable(vm.addr(2));
+        addresses2[2] = payable(0x000000000000000000000000000000000000dEaD);
+        uint[] memory scores2 = new uint[](3);
+        scores2[0] = 0;
+        scores2[1] = 0;
+        scores2[2] = impactEvaluator.MAX_SCORE();
+        impactEvaluator.setScores(2, addresses2, scores2);
+        assertEq(
+            impactEvaluator.participantIsReadyForTransfer(addresses2[0]),
+            true,
+            "participant 0 is now ready"
+        );
+        assertEq(
+            impactEvaluator.participantIsReadyForTransfer(addresses2[1]),
+            true,
+            "participant 1 is still ready"
+        );
     }
 
     function test_SetScoresAfterIncreaseMinBalanceForTransfer() public {

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -250,6 +250,8 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.setMinBalanceForTransfer(0);
         impactEvaluator.adminAdvanceRound();
 
+        scores[0] = 0;
+        scores[1] = impactEvaluator.MAX_SCORE();
         impactEvaluator.setScores(2, addresses, scores);
         assert(impactEvaluator.participantIsReadyForTransfer(addresses[0]));
     }
@@ -272,7 +274,14 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.setMinBalanceForTransfer(200 ether);
         impactEvaluator.adminAdvanceRound();
 
-        impactEvaluator.setScores(2, addresses, scores);
+        address payable[] memory addresses2 = new address payable[](2);
+        addresses2[0] = payable(vm.addr(1));
+        addresses2[1] = payable(0x000000000000000000000000000000000000dEaD);
+        uint[] memory scores2 = new uint[](2);
+        scores2[0] = 0;
+        scores2[1] = impactEvaluator.MAX_SCORE();
+        impactEvaluator.setScores(2, addresses2, scores2);
+
         // Still ready for transfer, although now below the rewards threshold
         assert(impactEvaluator.participantIsReadyForTransfer(addresses[0]));
     }

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -305,27 +305,52 @@ contract ImpactEvaluatorTest is Test {
         impactEvaluator.adminAdvanceRound();
         impactEvaluator.adminAdvanceRound();
 
-        address payable[] memory addresses = new address payable[](1);
+        address payable[] memory addresses = new address payable[](2);
         addresses[0] = payable(vm.addr(1));
-        uint[] memory scores = new uint[](1);
+        addresses[1] = payable(vm.addr(2));
+        uint[] memory scores = new uint[](2);
         scores[0] = impactEvaluator.MAX_SCORE();
+        scores[1] = 0;
 
         impactEvaluator.setScores(1, addresses, scores);
-        assert(impactEvaluator.participantIsReadyForTransfer(addresses[0]));
+        assertEq(
+            impactEvaluator.participantIsReadyForTransfer(vm.addr(1)),
+            true,
+            "participant 0 is ready"
+        );
+        assertEq(
+            impactEvaluator.participantIsReadyForTransfer(vm.addr(2)),
+            false,
+            "participant 1 is not ready"
+        );
 
         impactEvaluator.setMinBalanceForTransfer(200 ether);
         impactEvaluator.adminAdvanceRound();
 
-        address payable[] memory addresses2 = new address payable[](2);
+        address payable[] memory addresses2 = new address payable[](3);
         addresses2[0] = payable(vm.addr(1));
-        addresses2[1] = payable(0x000000000000000000000000000000000000dEaD);
-        uint[] memory scores2 = new uint[](2);
+        addresses2[1] = payable(vm.addr(2));
+        addresses2[2] = payable(0x000000000000000000000000000000000000dEaD);
+        uint[] memory scores2 = new uint[](3);
         scores2[0] = 0;
-        scores2[1] = impactEvaluator.MAX_SCORE();
+        scores2[1] = 0;
+        scores2[2] = impactEvaluator.MAX_SCORE();
         impactEvaluator.setScores(2, addresses2, scores2);
 
-        // Still ready for transfer, although now below the rewards threshold
-        assert(impactEvaluator.participantIsReadyForTransfer(addresses[0]));
+        assertEq(
+            impactEvaluator.participantIsReadyForTransfer(vm.addr(1)),
+            true,
+            "participant 0 is still ready"
+        );
+        assertEq(
+            impactEvaluator.participantIsReadyForTransfer(vm.addr(2)),
+            false,
+            "participant 1 is still not ready"
+        );
+
+        assertEq(impactEvaluator.readyForTransfer(0), vm.addr(1));
+        vm.expectRevert();
+        impactEvaluator.readyForTransfer(1);
     }
 
     function test_AdvanceRoundCleanUp() public {

--- a/test/ImpactEvaluator.t.sol
+++ b/test/ImpactEvaluator.t.sol
@@ -246,12 +246,12 @@ contract ImpactEvaluatorTest is Test {
 
         impactEvaluator.setScores(1, addresses, scores);
         assertEq(
-            impactEvaluator.participantIsReadyForTransfer(addresses[0]),
+            impactEvaluator.participantIsReadyForTransfer(vm.addr(1)),
             false,
             "participant 0 is not ready"
         );
         assertEq(
-            impactEvaluator.participantIsReadyForTransfer(addresses[1]),
+            impactEvaluator.participantIsReadyForTransfer(vm.addr(2)),
             true,
             "participant 1 is ready"
         );
@@ -269,15 +269,19 @@ contract ImpactEvaluatorTest is Test {
         scores2[2] = impactEvaluator.MAX_SCORE();
         impactEvaluator.setScores(2, addresses2, scores2);
         assertEq(
-            impactEvaluator.participantIsReadyForTransfer(addresses2[0]),
+            impactEvaluator.participantIsReadyForTransfer(vm.addr(1)),
             true,
             "participant 0 is now ready"
         );
         assertEq(
-            impactEvaluator.participantIsReadyForTransfer(addresses2[1]),
+            impactEvaluator.participantIsReadyForTransfer(vm.addr(2)),
             true,
             "participant 1 is still ready"
         );
+        assertEq(impactEvaluator.readyForTransfer(0), vm.addr(2));
+        assertEq(impactEvaluator.readyForTransfer(1), vm.addr(1));
+        vm.expectRevert();
+        impactEvaluator.readyForTransfer(2);
     }
 
     function test_SetScoresAfterIncreaseMinBalanceForTransfer() public {


### PR DESCRIPTION
Closes #80

If the new balance is above the threshold _and_ the participant isn't yet in the list of participants ready for transfer, add them. This is a good UX improvement, while only making `setScores()` a tad more expensive.